### PR TITLE
Potential fix for code scanning alert no. 2386: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -74,10 +74,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "retries": retry_attempts,
     }
 
+    sanitized_config = config.copy()
+    sanitized_config["password"] = "****"
     _LOGGER.debug(
         "Final config (entry_id=%s) => %s",
         entry.entry_id,
-        config,
+        sanitized_config,
     )
 
     # 3) API und Coordinator erstellen


### PR DESCRIPTION
Potential fix for [https://github.com/Xerolux/violet-hass/security/code-scanning/2386](https://github.com/Xerolux/violet-hass/security/code-scanning/2386)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. The best way to fix this without changing existing functionality is to create a sanitized version of the `config` dictionary that excludes sensitive information before logging it. This can be done by copying the `config` dictionary and removing or masking the sensitive fields before logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
