### PR TITLE
Fix Violet API client and service imports

### DIFF
--- a/custom_components/violet_pool_controller/climate.py
+++ b/custom_components/violet_pool_controller/climate.py
@@ -16,8 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN, CONF_ACTIVE_FEATURES
-from .api import ACTION_ON, ACTION_OFF, ACTION_AUTO, VioletPoolAPIError
+from .api import VioletPoolAPIError
+from .const import ACTION_AUTO, ACTION_OFF, ACTION_ON, CONF_ACTIVE_FEATURES, DOMAIN
 from .entity import VioletPoolControllerEntity
 from .device import VioletPoolDataUpdateCoordinator
 

--- a/custom_components/violet_pool_controller/cover.py
+++ b/custom_components/violet_pool_controller/cover.py
@@ -12,8 +12,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN, CONF_ACTIVE_FEATURES, COVER_FUNCTIONS, COVER_STATE_MAP
-from .api import ACTION_PUSH, VioletPoolAPIError
+from .const import (
+    ACTION_PUSH,
+    CONF_ACTIVE_FEATURES,
+    COVER_FUNCTIONS,
+    COVER_STATE_MAP,
+    DOMAIN,
+)
+from .api import VioletPoolAPIError
 from .entity import VioletPoolControllerEntity
 from .device import VioletPoolDataUpdateCoordinator
 

--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -1,30 +1,28 @@
-"""
-Violet Pool Controller - Unified Services
-Konsolidierte Service-Definitionen mit optimierter Struktur
-"""
-import logging
+"""Service handlers for the Violet Pool Controller integration."""
+
 import asyncio
+import logging
 from typing import Any
 
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_DEVICE_ID
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
+from .api import VioletPoolAPIError
 from .const import (
-    DOMAIN,
-    ACTION_ON,
-    ACTION_OFF,
+    ACTION_ALLAUTO,
+    ACTION_ALLOFF,
+    ACTION_ALLON,
     ACTION_AUTO,
     ACTION_MAN,
-    ACTION_ALLON,
-    ACTION_ALLOFF,
-    ACTION_ALLAUTO,
+    ACTION_OFF,
+    ACTION_ON,
     DEVICE_PARAMETERS,
+    DOMAIN,
 )
-from .api import VioletPoolAPIError
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- replace the Violet API client with a concrete implementation that handles command formatting, retries, and exposes the helper methods used by the integration
- clean up service, cover, and climate modules to rely on the constants module for action strings and to keep module headers well-formed

## Testing
- pytest *(fails: missing voluptuous dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69086b85ce9c8327bc659ebd1922a3a9