### PR TITLE
Optimize Violet polling and add diagnostic output service

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -48,6 +48,29 @@ API_READINGS = "/getReadings"
 API_SET_FUNCTION_MANUALLY = "/setFunctionManually"
 API_SET_DOSING_PARAMETERS = "/setDosingParameters"
 API_SET_TARGET_VALUES = "/setTargetValues"
+API_GET_CONFIG = "/getConfig"
+API_SET_CONFIG = "/setConfig"
+API_GET_CALIB_RAW_VALUES = "/getCalibRawValues"
+API_GET_CALIB_HISTORY = "/getCalibHistory"
+API_RESTORE_CALIBRATION = "/restoreOldCalib"
+API_SET_OUTPUT_TESTMODE = "/setOutputTestmode"
+
+# Default reading optimisation settings
+SPECIFIC_READING_GROUPS = (
+    "ADC",
+    "DOSAGE",
+    "RUNTIMES",
+    "PUMPPRIOSTATE",
+    "BACKWASH",
+    "SYSTEM",
+    "INPUT1",
+    "INPUT2",
+    "INPUT3",
+    "INPUT4",
+    "date",
+    "time",
+)
+SPECIFIC_FULL_REFRESH_INTERVAL = 10
 
 # =============================================================================
 # POOL CONFIGURATION

--- a/custom_components/violet_pool_controller/services.yaml
+++ b/custom_components/violet_pool_controller/services.yaml
@@ -160,3 +160,30 @@ manage_digital_rules:
             - trigger
             - lock
             - unlock
+
+test_output:
+  name: Output Test Mode
+  description: Temporarily activate a controller output for diagnostics
+  fields:
+    output:
+      description: Output identifier (e.g. PUMP, HEATER, SOLAR)
+      required: true
+      selector:
+        text:
+    mode:
+      description: Test mode (switch toggles, on forces on, off forces off)
+      default: SWITCH
+      selector:
+        select:
+          options:
+            - SWITCH
+            - ON
+            - OFF
+    duration:
+      description: Test duration in seconds
+      default: 120
+      selector:
+        number:
+          min: 1
+          max: 900
+          unit_of_measurement: s

--- a/custom_components/violet_pool_controller/translations/de.json
+++ b/custom_components/violet_pool_controller/translations/de.json
@@ -336,6 +336,15 @@
             },
             "firmware_version": {
                 "name": "📦 Firmware-Version"
+            },
+            "dosage_state": {
+                "name": "💧 Dosierstatus"
+            },
+            "daily_runtime": {
+                "name": "🕒 Tägliche Laufzeit"
+            },
+            "electrode_flow": {
+                "name": "🌊 Sonden-Anströmung"
             }
         },
         "binary_sensor": {

--- a/custom_components/violet_pool_controller/translations/en.json
+++ b/custom_components/violet_pool_controller/translations/en.json
@@ -336,6 +336,15 @@
             },
             "firmware_version": {
                 "name": "Firmware Version"
+            },
+            "dosage_state": {
+                "name": "Dosing State"
+            },
+            "daily_runtime": {
+                "name": "Daily Runtime"
+            },
+            "electrode_flow": {
+                "name": "Probe Flow"
             }
         },
         "binary_sensor": {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -504,6 +504,7 @@ def test_service_registration_registers_expected_services(hass: Any) -> None:
         "control_dmx_scenes",
         "set_light_color_pulse",
         "manage_digital_rules",
+        "test_output",
     }
 
 


### PR DESCRIPTION
## Summary
- add dedicated API helpers for targeted readings, configuration, and calibration interactions
- reuse the new API surface in the device to perform lighter incremental updates between full refreshes
- expose a diagnostic output test service with documentation, translations, and updated registration tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f40e9320c83278f9ca0b72a96581d)