### PR TITLE
Fix aiohttp session usage in config flow

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import VioletPoolAPI, VioletPoolAPIError
 from .const import (
@@ -301,7 +302,7 @@ class VioletPoolControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         test_api = VioletPoolAPI(
             host=host,
-            session=self.hass.helpers.aiohttp_client.async_get_clientsession(self.hass),
+            session=async_get_clientsession(self.hass),
             username=username,
             password=password,
             use_ssl=use_ssl,


### PR DESCRIPTION
## Summary
- use Home Assistant's async_get_clientsession to build the API client in the config flow
- import the aiohttp helper directly to avoid missing helpers attribute

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201b0160c08327b014b0405cbea725)