### PR TITLE
Add device info lookup to API

### DIFF
--- a/custom_components/violet_pool_controller/api.py
+++ b/custom_components/violet_pool_controller/api.py
@@ -254,6 +254,38 @@ class VioletPoolAPI:
             raise VioletPoolAPIError("Unexpected payload returned from getReadings")
         return response
 
+    async def get_device_info(self) -> dict[str, Any]:
+        """Fetch basic device metadata to verify connectivity."""
+
+        data = await self.get_readings()
+
+        def _lookup(keys: tuple[str, ...]) -> Any:
+            """Search common sections for the first matching key."""
+
+            sections: tuple[Mapping[str, Any] | Any, ...] = (
+                data,
+                data.get("DEVICE", {}),
+                data.get("SYSTEM", {}),
+                data.get("NETWORK", {}),
+            )
+
+            for key in keys:
+                for section in sections:
+                    if isinstance(section, Mapping) and key in section:
+                        return section[key]
+            return None
+
+        raw_device_id = _lookup(("device_id", "DEVICE_ID", "deviceId", "SERIAL_NUMBER", "serial"))
+        try:
+            device_id = int(str(raw_device_id).strip()) if raw_device_id is not None else 1
+        except (ValueError, TypeError):
+            device_id = 1
+
+        raw_name = _lookup(("device_name", "DEVICE_NAME", "name", "controller_name"))
+        device_name = str(raw_name).strip() if raw_name else "Violet Pool Controller"
+
+        return {"device_id": device_id, "device_name": device_name}
+
     async def get_specific_readings(self, categories: list[str] | tuple[str, ...]) -> dict[str, Any]:
         """Return a reduced data set for the provided categories."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,3 +137,26 @@ class TestVioletPoolAPI:
             # Sollte VioletPoolAPIError werfen
             with pytest.raises(VioletPoolAPIError, match="Invalid JSON"):
                 await api._request("/test", expect_json=True)
+
+    async def test_get_device_info_with_values(self, api):
+        """Test that device info is extracted when values are present."""
+
+        mock_payload = {
+            "DEVICE": {"DEVICE_ID": "42", "DEVICE_NAME": "Pool Alpha"},
+            "SYSTEM": {"FW": "1.2.3"},
+        }
+
+        with patch.object(api, "get_readings", AsyncMock(return_value=mock_payload)):
+            info = await api.get_device_info()
+
+        assert info["device_id"] == 42
+        assert info["device_name"] == "Pool Alpha"
+
+    async def test_get_device_info_defaults(self, api):
+        """Test that sensible defaults are returned when data is missing."""
+
+        with patch.object(api, "get_readings", AsyncMock(return_value={"SYSTEM": {}})):
+            info = await api.get_device_info()
+
+        assert info["device_id"] == 1
+        assert info["device_name"] == "Violet Pool Controller"


### PR DESCRIPTION
## Summary
- add a device info helper to validate connections and provide controller metadata
- cover the new helper with tests for populated and default responses

## Testing
- pytest tests/test_api.py *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201bd6c2648327913bf3f34e9621eb)