### PR TITLE
Await finish step in config flow

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -221,7 +221,7 @@ class VioletPoolControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.config_data["selected_sensors"] = selected_sensors
 
             # Proceed to finish step
-            return self.async_step_finish()
+            return await self.async_step_finish()
 
         # Show form for sensor selection
         return self.async_show_form(


### PR DESCRIPTION
## Summary
- ensure the sensors step awaits the finish step so the config flow returns a FlowResult
- prevent un-awaited coroutine errors when finalizing sensor selection

## Testing
- pytest tests/test_config_flow.py -q *(fails: ModuleNotFoundError: homeassistant)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201ece24f883278a2aeb1e34440157)