### PR TITLE
Fix options flow init to use base config entry handling

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -355,7 +355,7 @@ class VioletPoolControllerOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize the options flow."""
-        self.config_entry = config_entry
+        super().__init__(config_entry)
         self.options = dict(config_entry.options)
         self.config = dict(config_entry.data)
         self._sensor_data: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- initialize options flow via the base OptionsFlow init instead of setting config_entry directly

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692020022904832794ce9398791e98c6)