### PR TITLE
Handle unitless temperature diagnostics without warnings

### DIFF
--- a/custom_components/violet_pool_controller/sensor.py
+++ b/custom_components/violet_pool_controller/sensor.py
@@ -322,9 +322,14 @@ def determine_device_class(key: str, unit: str | None, raw_value=None) -> Sensor
         return None
     if key == "pH_value":
         return SensorDeviceClass.PH
-    if "temp" in key.lower():
-        return SensorDeviceClass.TEMPERATURE
     if unit == "°C":
+        return SensorDeviceClass.TEMPERATURE
+    # Temperature device class requires a valid temperature unit. Keep diagnostic
+    # sensors without units (e.g. SYSTEM_*_cpu_temperature) unitless for
+    # backwards-compatible statistics while avoiding Home Assistant warnings.
+    if unit is None:
+        return None
+    if "temp" in key.lower():
         return SensorDeviceClass.TEMPERATURE
     if unit == "%":
         return SensorDeviceClass.HUMIDITY


### PR DESCRIPTION
## Summary
- avoid assigning the temperature device class when no native unit is provided to prevent Home Assistant warnings for diagnostic sensors

## Testing
- python -m compileall custom_components/violet_pool_controller


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244192efa083279c43cfc2d15babf9)