### PR TITLE
Review code for errors and functionality

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -896,15 +896,16 @@ class VioletOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Build feature options with enhanced display
         feature_options = []
-        for feature_key in AVAILABLE_FEATURES:
-            if feature_key in ENHANCED_FEATURES:
-                info = ENHANCED_FEATURES[feature_key]
+        for feature in AVAILABLE_FEATURES:
+            feature_id = feature["id"]
+            if feature_id in ENHANCED_FEATURES:
+                info = ENHANCED_FEATURES[feature_id]
                 label = f"{info['icon']} {info['name']}"
             else:
-                label = feature_key.replace("_", " ").title()
+                label = feature["name"]
 
             feature_options.append(
-                selector.SelectOptionDict(value=feature_key, label=label)
+                selector.SelectOptionDict(value=feature_id, label=label)
             )
 
         return self.async_show_form(

--- a/custom_components/violet_pool_controller/error_codes.py
+++ b/custom_components/violet_pool_controller/error_codes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict
 
 # The dictionary below is intentionally focused on the most common error codes
 # observed in production systems.  Unknown codes fall back to a generic

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/xerolux/violet-hass",
+  "homeassistant": "2024.4.0",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",


### PR DESCRIPTION
- Fix config_flow.py: AVAILABLE_FEATURES iteration bug in options flow (was treating dict items as strings, now properly extracts feature["id"])
- Add minimum Home Assistant version (2024.4.0) to manifest.json (Platform.SELECT requires HA 2024.4.0+)
- Remove unused import 'List' from error_codes.py

## Summary by Sourcery

Fix feature selection options flow and align the integration with required Home Assistant version.

Bug Fixes:
- Correct feature options construction in the config flow to use feature IDs and names from AVAILABLE_FEATURES consistently.

Build:
- Declare a minimum supported Home Assistant version 2024.4.0 in the integration manifest.

Chores:
- Remove an unused import from the error codes module.