### PR TITLE
Update dependencies and compatibility baseline

### DIFF
--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -5,10 +5,10 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/xerolux/violet-hass",
-  "homeassistant": "2024.4.0",
+  "homeassistant": "2024.12.3",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
-  "requirements": ["aiohttp>=3.8.0"],
+  "requirements": ["aiohttp>=3.9.5"],
   "version": "0.2.0-beta.4"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
   "content_in_root": false,
   "render_readme": true,
   "zip_release": true,
-  "homeassistant": "2024.7.0"
+  "homeassistant": "2024.12.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # requirements.txt
-homeassistant>=2024.12.0
-aiohttp>=3.8.0
-voluptuous>=0.13
+# Updated for Home Assistant 2026 compatibility baseline
+homeassistant>=2024.12.3
+aiohttp>=3.9.5
+voluptuous>=0.14.2

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -83,6 +83,7 @@ def _install_homeassistant_stubs() -> None:
         CLIMATE = "climate"
         COVER = "cover"
         NUMBER = "number"
+        SELECT = "select"
 
     const_module.Platform = Platform
 


### PR DESCRIPTION
## Summary
- raise Home Assistant compatibility declaration and dependency versions to the current baseline
- align integration metadata with the updated minimum versions
- extend Home Assistant test stubs to cover the select platform constant

## Testing
- not run (environment could not install Home Assistant dependencies due to proxy restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953c2dcbdbc83278957ac1ac69241a1)

## Summary by Sourcery

Update Home Assistant integration to the latest supported compatibility baseline and align dependencies and tests accordingly.

New Features:
- Extend Home Assistant test stubs to support the select platform constant.

Enhancements:
- Raise core dependency versions (homeassistant, aiohttp, voluptuous) to the new compatibility baseline.
- Update integration manifest to declare the newer Home Assistant minimum version and matching aiohttp requirement.