### PR TITLE
Clean up ProCon.IP constants from const.py and const_api.py

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -44,12 +44,6 @@ CONF_SELECTED_SENSORS = "selected_sensors"
 CONF_POOL_SIZE = "pool_size"
 CONF_POOL_TYPE = "pool_type"
 CONF_DISINFECTION_METHOD = "disinfection_method"
-CONF_CONTROLLER_TYPE = "controller_type"
-CONF_ERROR_TOLERANCE = "error_tolerance"
-
-# Controller Types
-CONTROLLER_TYPE_VIOLET = "violet"
-CONTROLLER_TYPE_PROCONIP = "proconip"
 
 # Default Values
 DEFAULT_POLLING_INTERVAL = 10
@@ -61,8 +55,6 @@ DEFAULT_CONTROLLER_NAME = "Violet Pool Controller"
 DEFAULT_POOL_SIZE = 50
 DEFAULT_POOL_TYPE = "outdoor"
 DEFAULT_DISINFECTION_METHOD = "chlorine"
-DEFAULT_CONTROLLER_TYPE = CONTROLLER_TYPE_VIOLET
-DEFAULT_ERROR_TOLERANCE = 2
 
 # =============================================================================
 # POOL CONFIGURATION

--- a/custom_components/violet_pool_controller/const_api.py
+++ b/custom_components/violet_pool_controller/const_api.py
@@ -25,15 +25,6 @@ API_GET_WEATHER_DATA = "/getWeatherdata"
 API_GET_OVERALL_DOSING = "/getOverallDosing"
 API_GET_OUTPUT_STATES = "/getOutputstates"
 
-# =============================================================================
-# PROCONIP API ENDPOINTS
-# =============================================================================
-
-PROCONIP_API_GETSTATE = "/GetState.csv"
-PROCONIP_API_USRCFG_CGI = "/cgi-bin/usrcfg.cgi"
-PROCONIP_API_COMMAND = "/cgi-bin/command.cgi"
-PROCONIP_API_SETSTATE = "/cgi-bin/setstate.cgi"
-
 # Settings for optimizing data refreshes by fetching specific groups.
 SPECIFIC_READING_GROUPS = (
     "ADC",


### PR DESCRIPTION
Removed all ProCon.IP-related constants:
- CONF_CONTROLLER_TYPE, CONF_ERROR_TOLERANCE
- CONTROLLER_TYPE_VIOLET, CONTROLLER_TYPE_PROCONIP
- DEFAULT_CONTROLLER_TYPE, DEFAULT_ERROR_TOLERANCE
- PROCONIP_API_GETSTATE and related endpoints

The integration is now fully focused on Violet Pool Controllers only.

## Summary by Sourcery

Remove legacy ProCon.IP-specific configuration and API constants so the integration targets Violet pool controllers only.

Enhancements:
- Drop unused ProCon.IP API endpoint constants from the API constants module.
- Remove ProCon.IP controller type and error tolerance configuration and defaults from the core constants module.