### PR TITLE
fix: remove wrong RPM unit from PUMP_RPM state code sensors

### DIFF
--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -344,7 +344,7 @@ SETPOINT_DEFINITIONS = [
         "device_class": None,
         "feature_id": "filter_control",
         "entity_category": EntityCategory.CONFIG,
-        "setpoint_fields": ["PUMP_RPM_2", "PUMP_SPEED", "pump_speed"],
+        "setpoint_fields": ["PUMP_SPEED", "pump_speed"],
         "indicator_fields": ["PUMP", "PUMP_RPM_2", "PUMP_RPM_2_VALUE"],
     },
     # Dosing Canister Volumes

--- a/custom_components/violet_pool_controller/const_sensors.py
+++ b/custom_components/violet_pool_controller/const_sensors.py
@@ -99,8 +99,8 @@ UNIT_MAP = {
     "ADC5_value": "V",
     "IMP1_value": "cm/s",
     "IMP2_value": "m³/h",
-    # Pump RPMs
-    **{f"PUMP_RPM_{i}": "RPM" for i in range(4)},
+    # Pump RPMs - only _VALUE sensors carry actual RPM measurements
+    # PUMP_RPM_{i} (without _VALUE) returns a state code (0-6), not a speed in RPM
     **{f"PUMP_RPM_{i}_VALUE": "RPM" for i in range(4)},
 }
 
@@ -126,6 +126,8 @@ NO_UNIT_SENSORS = {
     "SYSTEM_CARRIER_CPU_TEMPERATURE",
     "SYSTEM_DOSAGEMODULE_CPU_TEMPERATURE",
     "SYSTEM_memoryusage",
+    # PUMP_RPM_{i} (without _VALUE) are state code sensors (values 0-6), not RPM measurements
+    *(f"PUMP_RPM_{i}" for i in range(4)),
 }
 
 # =============================================================================


### PR DESCRIPTION
PUMP_RPM_0..3 sensors return state codes (0-6) from the controller API,
not actual rotational speed values. Displaying them as "4 RPM" was
semantically incorrect and confusing - value 4 means "Manual ON (Forced)".

- Remove PUMP_RPM_0..3 from UNIT_MAP (no more "RPM" unit for state sensors)
- Add PUMP_RPM_0..3 to NO_UNIT_SENSORS (also suppresses state_class=MEASUREMENT)
- PUMP_RPM_0..3_VALUE sensors retain "RPM" unit (actual speed measurements)

https://claude.ai/code/session_01SwGpPGyzZGb3WPovG2SVMc

## Summary by Sourcery

Adjust pump-related sensors and number entities to correctly treat PUMP_RPM state codes as non-RPM state sensors and derive pump speed from them.

Bug Fixes:
- Remove the RPM unit and measurement state_class from PUMP_RPM_0..3 state code sensors so they are no longer presented as RPM values.

Enhancements:
- Derive the PUMP_SPEED number value from the active PUMP_RPM_{i} state codes instead of relying on PUMP_RPM_2 as a setpoint field.
- Restrict RPM units to the PUMP_RPM_{i}_VALUE sensors, which expose actual rotational speed measurements.