### PR TITLE
Fix broken logo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Für den vollständigen Changelog siehe [CHANGELOG.md](docs/CHANGELOG.md).
 [forum]: https://community.home-assistant.io/
 [buymeacoffee]: https://www.buymeacoffee.com/xerolux
 [buymeacoffee-badge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[logo]: https://github.com/xerolux/violet-hass/raw/main/logo.png
+[logo]: https://github.com/xerolux/violet-hass/raw/main/custom_components/violet_pool_controller/logo.png
 [pbuy]: https://github.com/xerolux/violet-hass/raw/main/screenshots/violetbm.jpg
 [github]: https://github.com/xerolux/violet-hass
 [github-shield]: https://img.shields.io/badge/GitHub-xerolux/violet--hass-blue?style=for-the-badge&logo=github


### PR DESCRIPTION
Updated the README.md to point to the correct location of the logo file: `custom_components/violet_pool_controller/logo.png`.
Previously, it was pointing to the root `logo.png` which does not exist.

---
*PR created automatically by Jules for task [16228761504843725527](https://jules.google.com/task/16228761504843725527) started by @Xerolux*

## Summary by Sourcery

Documentation:
- Fix README logo reference to point to the existing logo image under custom_components/violet_pool_controller.