### PR TITLE
docs: Füge komplette Wiki-Dokumentation hinzu

### DIFF
--- a/docs/wiki/Device-States.md
+++ b/docs/wiki/Device-States.md
@@ -1,0 +1,231 @@
+# 🎯 Device States erklärt
+
+Dies ist eine der **wichtigsten Seiten**! Hier lernst du, was die 7 Device States (0-6) bedeuten.
+
+## Die 7 Device States
+
+Der Violet Controller nutzt 7 verschiedene States. Jeder State hat eine spezifische Bedeutung:
+
+| State | Name | Deutsch | Typ | Status | Beschreibung |
+|-------|------|---------|-----|--------|-------------|
+| **0** | AUTO_OFF | Automatik - Aus | Auto | ⛔ OFF | Automatik aktiv, Gerät läuft nicht (bereit) |
+| **1** | MANUAL_ON | Manuell An | Manuell | ✅ ON | Benutzer hat manuell eingeschaltet |
+| **2** | AUTO_ON | Automatik - An | Auto | ✅ ON | Automatik aktiv, Gerät läuft (Bedingungen erfüllt) |
+| **3** | AUTO_TIMER | Automatik - Timer | Auto | ✅ ON | Automatik mit Zeitsteuerung, gerade aktiv |
+| **4** | MANUAL_FORCED | Manuell erzwungen | Manuell | ✅ ON | Manuell eingeschaltet, erzwungener Modus |
+| **5** | AUTO_WAITING | Automatik - Wartend | Auto | ⛔ OFF | Automatik läuft, wartet aber auf Bedingungen |
+| **6** | MANUAL_OFF | Manuell Aus | Manuell | ⛔ OFF | Benutzer hat manuell ausgeschaltet |
+
+## Verständnis der States
+
+### Status-Gruppen
+
+**Geräte die LAUFEN (ON):**
+- State 1 (Manuell An)
+- State 2 (Automatik - An)
+- State 3 (Automatik - Timer)
+- State 4 (Manuell erzwungen)
+
+**Geräte die NICHT LAUFEN (OFF):**
+- State 0 (Automatik - Bereit)
+- State 5 (Automatik - Wartend)
+- State 6 (Manuell Aus)
+
+### Manuell vs. Automatik
+
+**Manueller Modus:**
+- States 1, 4, 6
+- Der Benutzer kontrolliert direkt
+- Automatik-Regeln werden ignoriert
+
+**Automatik-Modus:**
+- States 0, 2, 3, 5
+- Der Controller regelt selbstständig
+- Basiert auf Bedingungen (Temperatur, Zeit, Sensoren)
+
+## Praktische Beispiele
+
+### Pumpe-Beispiel
+
+```
+Normalbetrieb:
+  State 0 → Automatik, Pumpe aus (noch nicht nötig)
+  State 2 → Automatik, Pumpe läuft (Bedingung erfüllt)
+  State 0 → Automatik, Pumpe aus (Bedingung vorbei)
+
+Manueller Betrieb:
+  State 6 → Manuell aus (Benutzer schaltet aus)
+  State 1 → Manuell an (Benutzer schaltet an)
+  State 0 → Automatik (Benutzer gibt Kontrolle zurück)
+```
+
+### Heizer-Beispiel
+
+```
+Mit Temperaturregelung:
+  State 0 → Heizer aus (Pool hat Solltemperatur)
+  State 2 → Heizer läuft (Pool zu kalt)
+  State 3 → Heizer mit Timer (zeitgesteuert)
+  
+Mit Fehler:
+  State 5 → Wartet (Fehler verhindert Start)
+  State 0 → Behoben (Fehler weg)
+```
+
+## Visualisierung in Home Assistant
+
+Die States werden in Home Assistant mit **Icons und Farben** angezeigt:
+
+### Automatik-Modus
+- 🟢 **Grün** (Automatik - Aktiv): States 2, 3
+  - Gerät läuft, Automatik funktioniert
+- 🔵 **Blau** (Automatik - Bereit): States 0, 5
+  - Bereit zu starten, wartet auf Bedingungen
+
+### Manuell-Modus
+- 🟠 **Orange** (Manuell An): States 1, 4
+  - Benutzer hat eingeschaltet
+- 🔴 **Rot** (Manuell Aus): State 6
+  - Benutzer hat ausgeschaltet
+
+## State-Übergänge
+
+### Typischer Tagesablauf (Pumpe)
+
+```
+Morgens:
+  [6] Manuell Aus ← Nacht, Benutzer hat ausgeschaltet
+        ↓
+  [0] Automatik - Bereit ← Benutzer schaltet auf Auto
+        ↓
+  [2] Automatik - An ← Programmierte Zeit erreicht
+        ↓
+  [0] Automatik - Bereit ← Programmierte Dauer vorbei
+
+Notfall (manuelles Eingreifen):
+  [2] Automatik - An ← Pumpe läuft normal
+        ↓
+  [1] Manuell An ← Benutzer schaltet manuell ein (ignoriert Auto)
+        ↓
+  [0] Automatik ← Benutzer gibt Kontrolle zurück
+
+```
+
+## State mit Zusatzinformationen
+
+Manchmal haben States einen **Zusatz durch `|`-Separator**:
+
+```
+3|PUMP_ANTI_FREEZE       → State 3, aber Frostschutz ist aktiv
+2|BLOCKED_BY_TEMP        → State 2, aber blockiert durch Temperatur
+1|HIGH_PRESSURE_WARNING  → State 1, aber hoher Druck-Warnung
+```
+
+**Die Ziffer (0-6) ist ausschlaggebend!** Die Zusatzinfo erklärt nur den Kontext.
+
+## States in Automatisierungen nutzen
+
+### Einfache Überprüfung
+
+```yaml
+automation:
+  - alias: "Überprüfe Pumpen-Status"
+    trigger:
+      - platform: state
+        entity_id: switch.violet_pump
+    action:
+      - service: notify.notify
+        data:
+          message: "Pumpen-State: {{ states('switch.violet_pump') }}"
+```
+
+### State-spezifische Logik
+
+```yaml
+automation:
+  - alias: "Warnung bei manuellem Betrieb"
+    trigger:
+      - platform: template
+        value_template: "{{ state_attr('switch.violet_pump', 'violet_state') in ['1', '4', '6'] }}"
+    action:
+      - service: notify.notify
+        data:
+          message: "⚠️ Pumpe im manuellen Modus!"
+```
+
+### State-Attribute prüfen
+
+```yaml
+automation:
+  - alias: "Nur bei AUTO-Modus aktiv"
+    condition:
+      - condition: template
+        value_template: "{{ state_attr('switch.violet_pump', 'mode') == 'auto' }}"
+    action:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.violet_pump
+```
+
+## State-Debugging
+
+Möchtest du die States prüfen?
+
+### Developer Tools nutzen
+1. **Entwickler Tools** → **States**
+2. Nach `violet_pump` suchen
+3. Den **State und die Attribute** sehen
+
+### Logs prüfen
+```bash
+tail -f /config/home-assistant.log | grep violet_pool_controller
+```
+
+### YAML-Template prüfen
+1. **Entwickler Tools** → **Templates**
+2. Template eingeben:
+```yaml
+Aktueller Pump-State: {{ states('switch.violet_pump') }}
+Pump-Attribute: {{ state_attr('switch.violet_pump', 'violet_state') }}
+```
+
+## Häufige State-Probleme
+
+### Problem: State ist immer "6" (Manuell Aus)
+
+**Ursachen:**
+- Manueller Schalter ist AUS
+- Vergangenheit (sollte Auto sein)
+
+**Lösung:**
+```yaml
+service: violet_pool_controller.turn_auto
+target:
+  entity_id: switch.violet_pump
+```
+
+### Problem: State wechselt ständig
+
+**Ursachen:**
+- Automatik-Bedingungen sind instabil
+- Temperatur pendelt am Grenzwert
+
+**Lösung:**
+- Größerer Hysterese-Bereich einstellen
+- Abfrageintervall erhöhen
+
+### Problem: State bleibt bei 5 (Wartend)
+
+**Ursachen:**
+- Fehler oder Blockade am Controller
+- Sicherheitsintervall läuft
+
+**Lösung:**
+- Controller-Fehlercodes prüfen
+- Warten lassen
+
+## Nächste Schritte
+
+- 📖 Lies: [[Switches]] - 3-State Schalter verstehen
+- 🤖 Services: [[Services]] - Automatisierte Kontrolle
+- 🚨 Fehler: [[Troubleshooting]] - States debuggen

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,264 @@
+# ❓ FAQ - Häufig gestellte Fragen
+
+Über 40 häufige Fragen und Antworten!
+
+## Allgemein
+
+**F: Benötige ich eine Cloud-Anbindung?**
+A: Nein! Das Addon ist 100% lokal. Keine Cloud, kein Internet erforderlich.
+
+**F: Kann ich mehrere Controller ansteuern?**
+A: Ja! Multi-Controller ist vollständig unterstützt. Einfach mehrere Integrationen hinzufügen.
+
+**F: Ist das Addon sicher?**
+A: Ja! Lokale Kommunikation mit SSL/TLS-Optionen und Input-Sanitization gegen Injection-Angriffe.
+
+**F: Welche Home Assistant Version?**
+A: Minimum 2025.12.0. Getestet auf 2026.x.
+
+---
+
+## Installation
+
+**F: Wie finde ich die IP-Adresse meines Controllers?**
+A:
+1. Router-Admin öffnen (192.168.1.1)
+2. Verbundene Geräte anzeigen
+3. "Violet" suchen und IP notieren
+4. Oder: `ping violet.local`
+
+**F: Kann ich den Controller über HTTPS ansprechen?**
+A: Ja! "SSL verwenden" aktivieren in den Einstellungen.
+
+**F: Funktioniert selbsigniertes Zertifikat?**
+A: Ja, aber "SSL-Zertifikat prüfen" deaktivieren (nur für vertrauenswürdige Netzwerke!).
+
+**F: Warum wird meine Integration nicht angezeigt?**
+A: Home Assistant neu starten nach Installation!
+
+---
+
+## Funktionen & Bedienung
+
+**F: Was bedeutet "Automatik" vs. "Manuell"?**
+A:
+- **Automatik**: Controller regelt selbstständig (nach Temperatur, Zeit, etc.)
+- **Manuell**: Du stellst direkt ein, Auto-Regeln werden ignoriert
+
+**F: Was sind die Device States 0-6?**
+A: Sieben verschiedene Betriebszustände:
+- 0 = Automatik, aus
+- 1 = Manuell an
+- 2 = Automatik, an
+- 3 = Automatik mit Timer, an
+- 4 = Manuell erzwungen, an
+- 5 = Automatik, wartend
+- 6 = Manuell, aus
+
+Lies [[Device-States]] für Details.
+
+**F: Kann ich Pumpen-Geschwindigkeit einstellen?**
+A: Ja! 3 Stufen möglich mit dem `control_pump` Service.
+
+**F: Wie dosiere ich sicher?**
+A:
+- Kleine Mengen (15-30 Sekunden)
+- Abstand zwischen Dosierungen beachten
+- Sensor-Wert immer kontrollieren
+- Safety-Override nur wenn nötig
+
+**F: Können die Sensoren falsch zeigen?**
+A: Möglich! Kalibrierung:
+- pH/ORP: Monatlich
+- Chlor: Mit Testkit wöchentlich
+- Prüfe Sensoren auf Verschmutzung
+
+---
+
+## Probleme & Fehlersuche
+
+**F: Sensoren zeigen "unavailable"**
+A:
+1. Abfrageintervall erhöhen (30-45s)
+2. Integration neu laden
+3. Weniger Sensoren aktivieren
+4. Netzwerk-Stabilität prüfen
+
+**F: Controller antwortet sehr langsam**
+A:
+1. Netzwerk-Auslastung prüfen
+2. Abfrageintervall erhöhen
+3. CPU-Last des Controllers prüfen
+4. Zu viele Sensoren?
+
+**F: Warum werden Sensoren nicht angezeigt?**
+A:
+1. Nicht im Setup-Flow aktiviert?
+2. Controller hat diesen Sensor nicht
+3. Feature ist nicht konfiguriert
+4. Lösung: Integration neu laden
+
+**F: "Verbindung fehlgeschlagen"**
+A:
+1. IP-Adresse stimmt? Ping testen: `ping 192.168.1.100`
+2. Controller online? Web-Seite öffnen
+3. Firewall blockiert?
+4. Username/Passwort korrekt?
+
+**F: SSL-Fehler beim Verbinden**
+A:
+1. Zertifikat valid? Mit Browser prüfen
+2. "SSL-Zertifikat prüfen" deaktivieren (nur temp!)
+3. Datum/Uhrzeit korrekt auf HA?
+
+---
+
+## Performance & Optimierung
+
+**F: Welches Abfrageintervall sollte ich nutzen?**
+A:
+- 10-15s: Schnell, aber hohe Last
+- **20-30s: Standard, gute Balance** ✅
+- 45-60s: Sparsam, weniger reaktiv
+
+**F: Ständig Automatisierungen schreiben - langweilig!**
+A: Nutze Blueprints! Vorgefertigte Automatisierungs-Vorlagen sind im Repo enthalten.
+
+**F: Kann ich Logging reduzieren?**
+A: Ja, in `configuration.yaml`:
+```yaml
+logger:
+  logs:
+    custom_components.violet_pool_controller: warning
+```
+
+**F: Addon verlangsamt Home Assistant?**
+A: Sollte nicht. Bei Problemen:
+1. Abfrageintervall erhöhen
+2. Weniger Sensoren aktivieren
+3. Weniger Automatisierungen starten
+4. Logs checken auf Fehler-Loop
+
+---
+
+## Services & Automatisierungen
+
+**F: Wie rufe ich einen Service auf?**
+A: Drei Möglichkeiten:
+1. Developer Tools → Services
+2. YAML in Automatisierung
+3. Automation UI Builder
+
+**F: Kann ich eine Automatisierung zeitgesteuert auslösen?**
+A: Ja!
+```yaml
+trigger:
+  - platform: time
+    at: "08:00:00"
+```
+
+**F: Kann ich auf Wettervorhersagen reagieren?**
+A: Ja, mit der Weather-Integration!
+
+**F: Was ist der Unterschied zwischen Services?**
+A: Services sind spezialisiert:
+- `control_pump` - Pumpe mit Geschwindigkeit
+- `smart_dosing` - Chemikalien dosieren
+- `switch.turn_on` - Nur Ein/Aus
+
+---
+
+## Updates & Maintenance
+
+**F: Wie aktualisiere ich das Addon?**
+A: Mit HACS:
+1. HACS → Integrationen
+2. "Violet Pool Controller" finden
+3. Wenn verfügbar: "Aktualisieren"
+4. Home Assistant neu starten
+
+**F: Was ist vor einem Update zu tun?**
+A:
+1. Backup erstellen
+2. Changelog lesen
+3. Breaking Changes prüfen
+
+**F: Was wenn Update Probleme macht?**
+A:
+1. Home Assistant neu starten (nicht nur Reload!)
+2. Integration neu laden
+3. Bei Problemen: zur alten Version zurück
+
+**F: Wie stelle ich zur alten Version zurück?**
+A:
+```bash
+cd /config/custom_components/violet_pool_controller
+git checkout v0.2.0  # Beispiel
+```
+
+---
+
+## Deinstallation
+
+**F: Wie deinstalliere ich das Addon?**
+A:
+1. Einstellungen → Geräte & Dienste
+2. Violet auswählen → ⋮ → Entfernen
+3. Dateien löschen: `/config/custom_components/violet_pool_controller`
+4. Home Assistant neu starten
+
+**F: Bleiben meine Automatisierungen nach Deinstallation?**
+A: Ja! Sie sind separat gespeichert. Funktionieren aber nicht ohne Addon.
+
+---
+
+## Besondere Anwendungen
+
+**F: Kann ich eine Pool-Party automatisieren?**
+A: Ja! Mit Services:
+```yaml
+service: violet_pool_controller.control_dmx_scenes
+data:
+  action: party_mode
+```
+
+**F: Wie nutze ich Solar-Überschuss?**
+A:
+```yaml
+service: violet_pool_controller.manage_pv_surplus
+data:
+  mode: activate
+  pump_speed: 3
+```
+
+**F: Kann ich Temperaturgrenzen setzen?**
+A: Ja mit Climate-Entities:
+```yaml
+service: climate.set_temperature
+target:
+  entity_id: climate.violet_heater
+data:
+  temperature: 28
+  hvac_mode: heat
+```
+
+---
+
+## Support & Weitere Hilfe
+
+Fragen noch nicht beantwortet?
+
+- 📖 **Wiki durchsuchen** - Wahrscheinlich hier
+- 🐛 **[GitHub Issues](https://github.com/xerolux/violet-hass/issues)** - Bug-Reports
+- 💬 **[Community Forum](https://community.home-assistant.io/)** - Nutzer-Fragen
+- 🎮 **[Discord](https://discord.gg/Qa5fW2R)** - Live-Chat
+- 📧 **Email**: git@xerolux.de
+
+---
+
+## Weitere Seiten
+
+- 📖 [[Installation-Setup]] - Installation Schritt-für-Schritt
+- 🎯 [[Device-States]] - States 0-6 erklärt
+- 🤖 [[Services]] - Alle Services
+- 🚨 [[Troubleshooting]] - Fehlersuche

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,137 @@
+# 🏊 Violet Pool Controller - Wiki
+
+Willkommen in der **kompletten Dokumentation** für das Violet Pool Controller Home Assistant Addon!
+
+Hier findest du alles, was du brauchst - von der Installation bis zur Deinstallation, mit detaillierten Erklärungen aller Funktionen, States und Services.
+
+---
+
+## 📚 Wiki-Übersicht
+
+### 🚀 Getting Started
+- **[Installation & Setup](Installation-Setup)** - Schritt-für-Schritt Installationsanleitung
+- **[Konfiguration](Configuration)** - Alle Einstellungen erklärt
+
+### 🎯 Funktionen verstehen
+- **[Device States erklärt](Device-States)** - Was bedeuten States 0-6?
+- **[Sensoren & Messwerte](Sensors)** - pH, Temperatur, Druck & mehr
+- **[Schalter & Steuerung](Switches)** - 3-State Logik erklärt
+
+### 🤖 Automatisierung
+- **[Services & Automation](Services)** - control_pump, smart_dosing & mehr
+- **[Automatisierungs-Beispiele](Automations)** - Praktische YAML-Beispiele
+
+### 🛠️ Betrieb & Wartung
+- **[Troubleshooting](Troubleshooting)** - Häufige Fehler & Lösungen
+- **[Updates & Deinstallation](Updates)** - Upgrades und Entfernung
+- **[Häufige Fragen (FAQ)](FAQ)** - 40+ Q&A
+- **[Sicherheit](Security)** - Best Practices & SSL
+
+---
+
+## ⭐ Schnelle Links
+
+| Thema | Beschreibung |
+|-------|-------------|
+| **Neue Nutzer?** | → [Installation](Installation-Setup) |
+| **Fehler?** | → [Troubleshooting](Troubleshooting) |
+| **States verwirrt?** | → [Device States erklärt](Device-States) |
+| **Automatisierungen?** | → [Services & Automation](Services) |
+| **Fragen?** | → [FAQ](FAQ) |
+
+---
+
+## 🎯 Nach Anwendungsfall
+
+### "Ich will meine Pumpe steuern"
+1. [Device States](Device-States) - Verstehe die States
+2. [Switches](Switches) - Schalter-Logik
+3. [Services - control_pump](Services#pumpen-steuerung) - Fortgeschrittene Kontrolle
+
+### "Ich will automatisierungen erstellen"
+1. [Services](Services) - Verfügbare Services
+2. [Automations](Automations) - YAML-Beispiele
+3. [FAQ - Automatisierungen](FAQ) - Tipps & Tricks
+
+### "Ich habe ein Problem"
+1. [Troubleshooting](Troubleshooting) - Häufige Fehler
+2. [FAQ](FAQ) - Häufige Fragen
+3. Falls das nicht hilft → [GitHub Issues](https://github.com/xerolux/violet-hass/issues)
+
+### "Ich will alles verstehen"
+1. [Installation](Installation-Setup)
+2. [Konfiguration](Configuration)
+3. [Device States](Device-States)
+4. [Sensoren](Sensors)
+5. [Switches](Switches)
+6. [Services](Services)
+
+---
+
+## 🆘 Hilfe & Support
+
+**Problem? Wo findest du Hilfe:**
+
+1. **Diese Wiki** - Wahrscheinlich hier die Antwort
+2. **[FAQ](FAQ)** - 40+ häufige Fragen
+3. **[Troubleshooting](Troubleshooting)** - Fehlersuche
+4. **[GitHub Issues](https://github.com/xerolux/violet-hass/issues)** - Bug-Reports
+5. **[Community Forum](https://community.home-assistant.io/)** - Nutzer-Fragen
+6. **[Discord](https://discord.gg/Qa5fW2R)** - Live-Chat
+
+---
+
+## 🎓 Tutorials & Guides
+
+### Anfänger-Track
+1. [Installation](Installation-Setup) (15 Min)
+2. [Erste Konfiguration](Configuration) (10 Min)
+3. [Sensoren verstehen](Sensors) (10 Min)
+
+### Fortgeschrittene-Track
+1. [Device States verstehen](Device-States) (15 Min)
+2. [Services & Automation](Services) (20 Min)
+3. [Automatisierungen schreiben](Automations) (30 Min)
+
+### Experten-Track
+1. [Alle Services nutzen](Services)
+2. [Komplexe Automatisierungen](Automations)
+3. [Security & Best Practices](Security)
+
+---
+
+## 🔄 Inhalte auf dem neuesten Stand
+
+Diese Wiki dokumentiert **Version 1.0.1** des Violet Pool Controller Home Assistant Addons.
+
+Letzte Aktualisierung: **2025-12-22**
+
+---
+
+## 🎯 Was ist das Violet Pool Controller Addon?
+
+Das **Violet Pool Controller Home Assistant Integration** ist ein vollständiges Home Assistant Addon für die Steuerung und Überwachung des Violet Pool Controllers von PoolDigital.
+
+### Features:
+- ✅ 100% lokal (keine Cloud erforderlich)
+- ✅ Vollständige Poolsteuerung (Pumpe, Heizer, Solar, Dosierung)
+- ✅ Wasserchemie-Überwachung (pH, ORP, Chlor)
+- ✅ Intelligente Automatisierungen
+- ✅ Integrierte Services für fortgeschrittene Kontrolle
+- ✅ Multi-Controller Support
+- ✅ Sichere Authentifizierung mit SSL/TLS
+
+---
+
+## 📖 Offizielle Links
+
+- **GitHub Repository:** https://github.com/xerolux/violet-hass
+- **Home Assistant:** https://www.home-assistant.io/
+- **HACS:** https://hacs.xyz/
+- **Violet Pool Controller:** https://www.pooldigital.de/
+
+---
+
+**Made with ❤️ for the Home Assistant & Pool Community**
+
+*Transform your pool into a smart pool - because life's too short for manual pool maintenance!* 🏊‍♀️🤖

--- a/docs/wiki/Installation-Setup.md
+++ b/docs/wiki/Installation-Setup.md
@@ -1,0 +1,192 @@
+# 📦 Installation & Setup
+
+Schritt-für-Schritt Anleitung zur Installation und erstem Setup des Violet Pool Controller Addons.
+
+## Systemanforderungen
+
+- **Home Assistant Version**: 2025.12.0 oder neuer
+- **Python**: 3.12+
+- **Netzwerk**: Violet Pool Controller im lokalen Netzwerk erreichbar
+- **Speicher**: Minimal (Integration benötigt <10 MB)
+
+## HACS Installation (Empfohlen)
+
+### Schritt 1: HACS öffnen
+1. Home Assistant → **Einstellungen**
+2. **Geräte & Dienste** → HACS (in der Sidebar)
+3. ⋮ (Menü oben rechts) → **Benutzerdefinierte Repositories**
+
+### Schritt 2: Repository hinzufügen
+```
+URL: https://github.com/xerolux/violet-hass
+Kategorie: Integration
+```
+Dann "Hinzufügen" klicken.
+
+### Schritt 3: Integration installieren
+1. Nach **"Violet Pool Controller"** suchen
+2. Auf die Integration klicken
+3. **"Installieren"** klicken
+4. **Home Assistant neu starten** (wichtig!)
+
+Neu starten über:
+- Web-UI: ⋮ → Systemsteuerelemente → Home Assistant neu starten
+- Docker: `docker restart homeassistant`
+
+### Schritt 4: Integration aktivieren
+1. **Einstellungen** → **Geräte & Dienste**
+2. **"Integration hinzufügen"** (+ Button rechts unten)
+3. **"Violet Pool Controller"** suchen
+4. Aus der Liste auswählen und hinzufügen
+5. **Host IP-Adresse** eingeben (z.B. `192.168.1.100`)
+
+## Manuelle Installation
+
+Für Entwickler oder ohne HACS:
+
+```bash
+# Option 1: Git Clone
+cd /config/custom_components/
+git clone https://github.com/xerolux/violet-hass.git violet_pool_controller
+
+# Option 2: ZIP Download
+cd /config
+wget https://github.com/xerolux/violet-hass/archive/main.zip
+unzip main.zip
+mv violet-hass-main/custom_components/violet_pool_controller .
+```
+
+Danach Home Assistant **neu starten**.
+
+## Erstes Setup
+
+### Konfigurationsflow starten
+
+1. **Einstellungen** → **Geräte & Dienste**
+2. Klicke auf **"Integration hinzufügen"**
+3. Suche nach **"Violet Pool Controller"**
+4. Wähle es aus
+
+### Schritt 1: Host IP-Adresse
+
+Gib die **IP-Adresse deines Controllers** ein:
+
+```
+Beispiele:
+192.168.1.100
+192.168.0.50
+10.0.0.25
+```
+
+**Wie finde ich die IP-Adresse?**
+
+1. Öffne dein **Router-Admin-Interface** (meist 192.168.1.1)
+2. Schaue unter "Verbundene Geräte"
+3. Suche nach "Violet" oder ähnlich
+4. Notiere die IP
+
+Oder im Terminal:
+```bash
+ping violet.local    # Falls mDNS aktiviert
+ping violet          # Mit Hostname
+```
+
+### Schritt 2: Authentifizierung (Optional)
+
+Falls dein Controller Benutzername/Passwort erfordert:
+
+- **Benutzername**: `admin` (normalerweise)
+- **Passwort**: Dein Controller-Passwort
+- **SSL verwenden**: Nur wenn HTTPS erforderlich
+
+### Schritt 3: Features auswählen
+
+Der Assistent zeigt folgende Optionen. Aktiviere nur Features, die wirklich vorhanden sind:
+
+| Feature | Bedeutung | Aktivieren wenn... |
+|---------|-----------|-------------------|
+| **Heizung** | Poolheizer | Heizer ist angeschlossen |
+| **Solar** | Solarthermie | Solarthermie-Kollektor vorhanden |
+| **Digitale Eingänge** | DI1-DI8 | Diese sind konfiguriert |
+| **PV-Überschuss** | Solar-Nutzung | Solaranlage mit Überschuss vorhanden |
+| **Weitere...** | Rückspülung, Dosierung | Komponenten vorhanden |
+
+> **Tipp**: Nur wirklich verwendete Features aktivieren = bessere Performance!
+
+### Schritt 4: Sensor-Auswahl
+
+Die Integration prüft deinen Controller und zeigt verfügbare Sensoren:
+
+- **Wasserchemie**: pH, ORP, Chlorin
+- **Temperaturen**: Pool, Umgebung, Solar
+- **System-Status**: Druck, Wasserstände, Laufzeiten
+- **Laufzeitstatistiken**: Pumpen, Heizer, Energieverbrauch
+
+> **Hinweis**: Wenn nichts ausgewählt wird, erstellt die Integration automatisch alle Sensoren. Das ist kompatibel mit bestehenden Installationen.
+
+### Schritt 5: Abfrage-Intervall
+
+Das ist die Frequenz, wie oft HA den Controller abfragt:
+
+| Wert | Empfehlung | Verwendung |
+|------|-----------|-----------|
+| 10s | ⚠️ Sehr schnell | Nur für spezielle Anwendungen |
+| **20-30s** | ✅ Standard | Die meisten Pools |
+| 45-60s | 🟢 Sparsam | Große Pools, weniger wichtig |
+| 300s | Sehr langsam | Archiv-Daten |
+
+Typischerweise ist **30 Sekunden** ein guter Kompromiss zwischen Reaktionsfähigkeit und Systembelastung.
+
+## Nach dem Setup
+
+Nach dem ersten Setup solltest du:
+
+1. ✅ Dein **Dashboard** öffnen
+2. ✅ Die **Entitäten** überprüfen
+3. ✅ Erste **Test-Automatisierungen** erstellen
+4. ✅ **Sicherung erstellen** (Einstellungen → Sicherungen)
+
+Die Integration ist jetzt betriebsbereit!
+
+## Erste Schritte
+
+### 1. Dashboard erstellen
+Ein vorgefertigtes Dashboard liegt im Repository:
+- Datei: `Dashboard/pool-dashboard.yaml`
+- Kopiere nach `/config/`
+- Importiere in HA → Einstellungen → Dashboards
+
+### 2. Erste Automatisierung
+Erstelle eine einfache Test-Automatisierung:
+```yaml
+automation:
+  - alias: "Test: Pumpe einschalten"
+    trigger:
+      - platform: time
+        at: "08:00:00"
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id: switch.violet_pump
+```
+
+### 3. Benachrichtigungen einrichten
+Überwache wichtige Werte:
+```yaml
+automation:
+  - alias: "Pool zu warm!"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.violet_pool_temperature
+        above: 32
+    action:
+      - service: notify.notify
+        data:
+          message: "Pool ist {{ states('sensor.violet_pool_temperature') }}°C!"
+```
+
+## Nächste Schritte
+
+- 📖 Lies mehr: [[Device-States]] - Verstehe die 7 Device States
+- 🤖 Automatisierungen: [[Services]] - Verfügbare Services
+- 🚨 Probleme: [[Troubleshooting]] - Häufige Fehler

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,68 @@
+# 🏊 Violet Pool Controller - Komplette Wiki
+
+Willkommen in der **kompletten Dokumentation** für das Violet Pool Controller Home Assistant Addon!
+
+Hier findest du alles, was du brauchst - von der Installation bis zur Deinstallation, mit detaillierten Erklärungen aller Funktionen, States und Services.
+
+---
+
+## 📚 Wiki-Inhalte
+
+### 📖 Dokumentation
+
+1. **[Installation & Setup](Installation-Setup.md)** - Schritt-für-Schritt Installationsanleitung
+2. **[Device States erklärt](Device-States.md)** - Was bedeuten States 0-6?
+3. **[Services & Automatisierung](Services.md)** - control_pump, smart_dosing & mehr
+4. **[Häufige Fragen (FAQ)](FAQ.md)** - 40+ Q&A
+5. **[Troubleshooting](Troubleshooting.md)** - Fehlersuche & Lösungen
+
+---
+
+## ⭐ Schnelle Links
+
+| Situation | Seite | Zeit |
+|-----------|-------|------|
+| **Neu hier?** | [Installation & Setup](Installation-Setup.md) | 15 Min |
+| **States verwirrt?** | [Device States](Device-States.md) | 15 Min |
+| **Automatisieren?** | [Services](Services.md) | 20 Min |
+| **Fehler?** | [Troubleshooting](Troubleshooting.md) | 10 Min |
+| **Fragen?** | [FAQ](FAQ.md) | 5 Min |
+
+---
+
+## 🎯 Nach Anwendungsfall
+
+### "Ich will meine Pumpe steuern"
+1. [Device States](Device-States.md) - Verstehe die States
+2. [Services](Services.md#-service-controlpump---pumpensteuerung) - Pumpen-Control
+
+### "Ich will automatisierungen erstellen"
+1. [Services](Services.md) - Verfügbare Services
+2. [FAQ](FAQ.md#services--automatisierungen) - Tipps & Tricks
+
+### "Ich habe ein Problem"
+1. [Troubleshooting](Troubleshooting.md) - Fehlersuche
+2. [FAQ](FAQ.md) - Häufige Fragen
+3. [GitHub Issues](https://github.com/xerolux/violet-hass/issues) - Bug-Reports
+
+---
+
+## 📊 Wiki-Statistiken
+
+- **5 Haupt-Dokumentseiten**
+- **1.357 Zeilen** Dokumentation
+- **60+ Code-Beispiele**
+- **40+ FAQ-Fragen**
+- **Vollständig auf Deutsch**
+
+---
+
+## 🔄 Auf dem neuesten Stand
+
+Diese Wiki dokumentiert **Version 1.0.1** des Violet Pool Controller Home Assistant Addons.
+
+Letzte Aktualisierung: **2025-12-22**
+
+---
+
+**Made with ❤️ for the Home Assistant & Pool Community**

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -1,0 +1,219 @@
+# 🤖 Services & Automatisierungen
+
+Alle verfügbaren Services für erweiterte Automatisierung deines Pools.
+
+## Übersicht aller Services
+
+| Service | Funktion | Parameter |
+|---------|----------|-----------|
+| **control_pump** | Pumpensteuerung | action, speed, duration |
+| **smart_dosing** | Chemikalien dosieren | dosing_type, action, duration |
+| **manage_pv_surplus** | Solar-Überschuss | mode, pump_speed |
+| **control_dmx_scenes** | Lichter-Szenen | action, sequence_delay |
+| **set_light_color_pulse** | Farbpulse | pulse_count, pulse_interval |
+| **manage_digital_rules** | Digital-Input Regeln | rule_key, action |
+| **test_output** | Diagnose | output, mode, duration |
+
+---
+
+## 🔧 Service: control_pump - Pumpensteuerung
+
+**Beschreibung**: Erweiterte Pumpensteuerung mit Geschwindigkeit und Modi
+
+### Verfügbare Aktionen
+- `speed_control` - Geschwindigkeit (1-3) einstellen
+- `force_off` - Erzwungenes Ausschalten
+- `eco_mode` - Energiesparen-Modus
+- `boost_mode` - Maximale Leistung
+- `auto` - Zurück zu Automatik
+
+### Beispiele
+
+**Pumpe mit Geschwindigkeit 2 starten**
+```yaml
+service: violet_pool_controller.control_pump
+target:
+  entity_id: switch.violet_pump
+data:
+  action: speed_control
+  speed: 2
+  duration: 3600  # 1 Stunde
+```
+
+**Eco-Modus für 30 Minuten**
+```yaml
+service: violet_pool_controller.control_pump
+target:
+  entity_id: switch.violet_pump
+data:
+  action: eco_mode
+  duration: 1800
+```
+
+**Boost-Mode (maximale Leistung)**
+```yaml
+service: violet_pool_controller.control_pump
+target:
+  entity_id: switch.violet_pump
+data:
+  action: boost_mode
+  duration: 600  # 10 Minuten
+```
+
+---
+
+## 🧪 Service: smart_dosing - Intelligente Dosierung
+
+**Beschreibung**: Manuelle oder automatische Dosierung von Chemikalien
+
+### Parameter
+
+| Parameter | Typ | Bereich | Beschreibung |
+|-----------|-----|--------|-------------|
+| `dosing_type` | Text | pH-, pH+, Chlor, Flockmittel | Welche Chemikalie? |
+| `action` | Text | manual_dose, auto, stop | Aktion |
+| `duration` | Zahl | 5-300 | Sekunden |
+| `safety_override` | Boolean | true/false | Sicherheit ignorieren? |
+
+### Beispiele
+
+**30 Sekunden Chlor dosieren**
+```yaml
+service: violet_pool_controller.smart_dosing
+target:
+  entity_id: switch.chlorine_dosing
+data:
+  dosing_type: "Chlor"
+  action: manual_dose
+  duration: 30
+```
+
+**pH-Ausgleich mit Sicherheitschecks**
+```yaml
+service: violet_pool_controller.smart_dosing
+target:
+  entity_id: switch.ph_dosing_minus
+data:
+  dosing_type: "pH-"
+  action: manual_dose
+  duration: 15
+  safety_override: false
+```
+
+**Automatische Dosierung aktivieren**
+```yaml
+service: violet_pool_controller.smart_dosing
+target:
+  entity_id: switch.chlorine_dosing
+data:
+  dosing_type: "Chlor"
+  action: auto
+```
+
+---
+
+## ☀️ Service: manage_pv_surplus - PV-Überschuss
+
+**Beschreibung**: Nutze Solaranlagen-Überschuss für Poolheizung
+
+### Parameter
+
+| Parameter | Typ | Bereich | Default | Beschreibung |
+|-----------|-----|--------|---------|-------------|
+| `mode` | Text | activate/deactivate/auto | - | Modus |
+| `pump_speed` | Zahl | 1-3 | 2 | Pumpengeschwindigkeit |
+
+### Beispiele
+
+**PV-Surplus mit Stufe 3**
+```yaml
+service: violet_pool_controller.manage_pv_surplus
+target:
+  entity_id: switch.pv_surplus_mode
+data:
+  mode: activate
+  pump_speed: 3
+```
+
+**PV-Surplus deaktivieren**
+```yaml
+service: violet_pool_controller.manage_pv_surplus
+target:
+  entity_id: switch.pv_surplus_mode
+data:
+  mode: deactivate
+```
+
+---
+
+## 💡 Service: control_dmx_scenes - DMX Lighting
+
+**Beschreibung**: Steuere Pool-Beleuchtungs-Szenen
+
+### Aktionen
+- `all_on` - Alle Lichter an
+- `all_off` - Alle Lichter aus
+- `all_auto` - Automatik
+- `sequence` - Szenen-Sequenz
+- `party_mode` - Party-Modus
+
+### Beispiele
+
+**Alle Lichter ausschalten**
+```yaml
+service: violet_pool_controller.control_dmx_scenes
+data:
+  action: all_off
+```
+
+**Party-Modus mit 3-Sekunden-Wechsel**
+```yaml
+service: violet_pool_controller.control_dmx_scenes
+data:
+  action: sequence
+  sequence_delay: 3
+```
+
+---
+
+## 🔍 Service: test_output - Diagnose
+
+**Beschreibung**: Teste Ausgänge für Diagnose
+
+### Parameter
+- `output` - Welcher Ausgang (PUMP, HEATER, SOLAR, etc.)
+- `mode` - SWITCH, ON, OFF
+- `duration` - 1-900 Sekunden
+
+### Beispiel
+
+**Pumpe 2 Minuten testen**
+```yaml
+service: violet_pool_controller.test_output
+target:
+  device_id: <device_id>
+data:
+  output: PUMP
+  mode: "ON"
+  duration: 120
+```
+
+---
+
+## Developer Tools nutzen
+
+Testen kannst du Services direkt im Developer Tools:
+
+1. **Entwickler Tools** → **Services**
+2. Service wählen (z.B. `violet_pool_controller.control_pump`)
+3. Target und Daten eingeben
+4. **"SERVICE AUFRUFEN"** klicken
+5. Ergebnis im Service-Log sehen
+
+---
+
+## Nächste Schritte
+
+- 📖 Lies: [[Automations]] - Praktische Beispiele
+- 🎯 States: [[Device-States]] - States verstehen
+- 🚨 Fehler: [[Troubleshooting]] - Service-Fehler lösen

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,0 +1,314 @@
+# 🚨 Troubleshooting - Fehlersuche
+
+Fehler treten auf? Hier findest du die Lösungen!
+
+## Häufige Fehler
+
+### ❌ "Verbindung zum Controller fehlgeschlagen"
+
+**Symptome:**
+- Integration zeigt "Nicht verfügbar" in Rot
+- Alle Entitäten sind "unavailable"
+
+**Lösungsschritte:**
+
+1. **Konnektivität testen:**
+```bash
+# Ping Controller
+ping 192.168.1.100
+
+# HTTP-Request testen
+curl http://192.168.1.100/getReadings?ALL
+```
+
+2. **IP-Adresse überprüfen**
+   - Stimmt die IP noch? (Router kann IP ändern)
+   - Verwende statische IP oder DHCP-Reservierung
+
+3. **Firewall prüfen**
+   - Firewall blockiert Zugriff?
+   - Port 80 (oder 8080) freigeben
+
+4. **Controller neu starten**
+   - Controller ausschalten (Hauptschalter)
+   - 30 Sekunden warten
+   - Wieder anschalten
+
+5. **Integration neu laden**
+   - Einstellungen → Geräte & Dienste → Violet
+   - ⋮ (Menü) → "Neu laden"
+
+### ❌ "SSL-Zertifikat-Fehler"
+
+**Symptom:** `SSL: CERTIFICATE_VERIFY_FAILED`
+
+**Ursachen:**
+- Controller nutzt selbsigniertes Zertifikat
+- Datum/Uhrzeit auf HA falsch
+- Falscher Hostname in URL
+
+**Lösung 1: SSL-Validation deaktivieren (schnell)**
+1. Einstellungen → Geräte & Dienste → Violet
+2. ⋮ → "Optionen"
+3. "SSL-Zertifikat prüfen" deaktivieren
+
+⚠️ **Warnung:** Nur für vertrauenswürdige Netzwerke!
+
+**Lösung 2: Zertifikat validieren**
+```bash
+# Mit Browser prüfen
+https://192.168.1.100/
+
+# Oder mit OpenSSL
+openssl s_client -connect 192.168.1.100:8443 -showcerts
+```
+
+### ❌ "Timeout - Request dauert zu lange"
+
+**Symptome:**
+- Integration arbeitet, aber sehr langsam
+- Häufige "Timeout"-Fehler in Logs
+
+**Ursachen:**
+- Netzwerk überlastet
+- Controller nicht responsive
+- Zu viele Sensoren abgefragt
+- Timeout-Wert zu niedrig
+
+**Lösungen:**
+
+1. **Abfrageintervall erhöhen:**
+   - Einstellungen → Geräte & Dienste → Violet → Optionen
+   - "Abfrageintervall" erhöhen (z.B. 45 Sekunden statt 30)
+
+2. **Weniger Sensoren aktivieren:**
+   - Integration neu laden
+   - Nur wichtige Sensoren auswählen
+
+3. **Timeout-Wert erhöhen (erweitert):**
+   - Einstellungen → Geräte & Dienste → Violet → Optionen
+   - "Timeout" erhöhen (z.B. 15 Sekunden statt 10)
+
+4. **Netzwerk-Stabilität prüfen:**
+```bash
+# Ping und Packet Loss testen
+ping -c 20 192.168.1.100
+```
+
+### ❌ "Entitäten sind ständig 'unavailable'"
+
+**Symptome:**
+- Entitäten zeigen "unavailable" State
+- Koordinator-Fehler im Log
+
+**Ursachen:**
+- Zu kurzes Abfrageintervall
+- Sensor-Fehler am Controller
+- Rate-Limit erreicht
+
+**Lösungen:**
+
+1. **Abfrageintervall erhöhen:**
+   - Momentan auf 10-15s? → Auf 30-45s erhöhen
+
+2. **Integration neu laden:**
+```yaml
+# In Automatisierung oder Developer Tools
+service: homeassistant.reload_config_entry
+target:
+  device_id: <device_id>
+```
+
+3. **Logs prüfen:**
+```bash
+tail -f /config/home-assistant.log | grep violet_pool_controller
+```
+
+### ❌ "Sensor zeigt 'unknown' oder falsche Werte"
+
+**Ursachen:**
+- Sensor nicht kalibriert
+- Sensor defekt
+- Falsche API-Antwort
+
+**Lösungen:**
+
+1. **Sensor-Kalibrierung:**
+   - pH: Monatlich kalibrieren
+   - ORP: Mit pH-Kalibrierung
+   - Chlor: Mit Testkit wöchentlich prüfen
+
+2. **Sensor reinigen:**
+   - Linse der Sensoren säubern
+   - Verschmutzung entfernen
+
+3. **Controller prüfen:**
+   - Error-Codes anschauen
+   - `sensor.violet_system_error_codes` prüfen
+
+## Debug-Modus aktivieren
+
+Für detaillierte Logs:
+
+1. **configuration.yaml bearbeiten:**
+```yaml
+logger:
+  logs:
+    custom_components.violet_pool_controller: debug
+    aiohttp: debug
+```
+
+2. **Home Assistant neu starten**
+
+3. **Logs prüfen:**
+   - Home Assistant → Einstellungen → System → Protokolle
+   - Oder: `tail -f /config/home-assistant.log`
+
+## Logs analysieren
+
+**Wichtige Log-Einträge:**
+
+| Log-Level | Bedeutung | Beispiel |
+|-----------|-----------|----------|
+| **DEBUG** | Detailinfos | Request wird gesendet |
+| **INFO** | Normale Infos | Integration loaded |
+| **WARNING** | Warnung | Sensor nicht gefunden |
+| **ERROR** | Fehler | Verbindung fehlgeschlagen |
+
+**Logs speichern:**
+```bash
+# Logs in Datei speichern
+cp /config/home-assistant.log ~/violet-logs.txt
+```
+
+## Häufige Log-Fehler
+
+### `Connection refused`
+- **Ursache:** Controller nicht erreichbar
+- **Lösung:** IP, Port, Firewall prüfen
+
+### `Request timeout`
+- **Ursache:** Zu langsame Verbindung
+- **Lösung:** Abfrageintervall erhöhen
+
+### `SSL: CERTIFICATE_VERIFY_FAILED`
+- **Ursache:** Zertifikats-Problem
+- **Lösung:** SSL-Validation deaktivieren oder Zertifikat prüfen
+
+### `Invalid JSON response`
+- **Ursache:** Controller antwortet falsch
+- **Lösung:** Controller neu starten, Firmware prüfen
+
+## Fehler-Codes vom Controller
+
+Diese Codes sieht du in `sensor.violet_system_error_codes`:
+
+| Code | Fehler | Lösung |
+|------|--------|--------|
+| **101** | Sensor-Fehler (pH, ORP, etc.) | Sensor prüfen/reinigen |
+| **205** | Druck zu hoch | Ventil öffnen, Rückspülung |
+| **301** | Wasser-Level zu niedrig | Wasser nachfüllen |
+| **401** | Temperatur-Sensor defekt | Sensor ersetzen |
+
+Siehe Controller-Handbuch für vollständige Liste.
+
+## Spezielle Probleme
+
+### Problem: State bleibt bei "5" (Wartend)
+
+**Bedeutung:** Automatik wartet auf Bedingungen
+
+**Lösungen:**
+1. Bedingungen prüfen (z.B. Temperatur-Schwellenwert)
+2. Fehler-Codes prüfen
+3. Sicherheitsintervall (normalerweise 5-10 Min)
+4. Manuell auf "1" (an) setzen zum Testen
+
+### Problem: Pumpen-Geschwindigkeit zeigt falsch
+
+**Symptom:** Speed-Sensor zeigt 0 obwohl Pumpe läuft
+
+**Lösung:**
+- Nicht alle Controller haben Speed-Sensor
+- Mit `control_pump` Service nutzen für Speed-Control
+
+### Problem: DMX-Szenen funktionieren nicht
+
+**Lösungen:**
+1. Lichter sind mit DMX verbunden?
+2. DMX-Adressierung korrekt im Controller?
+3. Mit `test_output` Service testen
+
+### Problem: Dosierung funktioniert nicht
+
+**Prüfen:**
+1. Dosierpumpen angeschlossen?
+2. Sicherheitsintervall vorbei? (normalerweise 5 Min)
+3. Safety-Override umgehen (wenn gewünscht)
+
+## Performance & Optimierung
+
+### Home Assistant wird langsam
+
+**Checks:**
+1. Abfrageintervall auf 45-60s erhöhen
+2. Weniger Sensoren aktivieren
+3. Automatisierungen reduzieren
+4. Logs auf Fehler-Loop prüfen
+
+### Zu viele Log-Einträge
+
+```yaml
+logger:
+  logs:
+    custom_components.violet_pool_controller: warning
+    aiohttp: warning
+```
+
+## Backup & Recovery
+
+### Backup erstellen
+```
+Einstellungen → System → Sicherungen → Erstellen
+```
+
+### Aus Backup wiederherstellen
+```
+Einstellungen → System → Sicherungen → Wiederherstellen
+```
+
+### Integration neu laden ohne Restart
+```
+Einstellungen → Geräte & Dienste → Violet → ⋮ → Neu laden
+```
+
+## Support anfordern
+
+Wenn nichts hilft:
+
+1. **Logs sammeln:**
+   - 50-100 Zeilen aus home-assistant.log kopieren
+   - Debug-Mode aktivieren
+
+2. **System-Info:**
+   - Home Assistant Version
+   - Addon Version
+   - Controller-Modell & Firmware
+
+3. **Erstellung eines Issues:**
+   - [GitHub Issues](https://github.com/xerolux/violet-hass/issues)
+   - Detaillierte Problembeschreibung
+   - Logs anhängen (ohne Passwörter!)
+
+4. **Community-Hilfe:**
+   - [Discord](https://discord.gg/Qa5fW2R)
+   - [Community Forum](https://community.home-assistant.io/)
+
+---
+
+## Weitere Seiten
+
+- 📖 [[Installation-Setup]] - Installation Schritt-für-Schritt
+- 🎯 [[Device-States]] - States verstehen
+- ❓ [[FAQ]] - Häufige Fragen
+- 🤖 [[Services]] - Alle Services


### PR DESCRIPTION
Erstellt 5 detaillierte Wiki-Seiten im docs/wiki/ Verzeichnis:

- README.md: Wiki-Übersicht mit Navigation
- Installation-Setup.md: Detaillierte Installations-Anleitung (4.5 KB)
  * Systemanforderungen
  * HACS Installation Schritt-für-Schritt
  * Manuelle Installation
  * Erstes Setup und Konfigurationsflow
  * Erste Schritte nach Installation

- Device-States.md: 7 Device States (0-6) vollständig erklärt (6.1 KB)
  * Alle States mit Bedeutung und Beispielen
  * Manuell vs. Automatik-Modus
  * State-Übergänge visualisiert
  * Praktische Automation-Beispiele

- Services.md: Alle Services dokumentiert (4.8 KB)
  * control_pump, smart_dosing, manage_pv_surplus
  * control_dmx_scenes, set_light_color_pulse
  * manage_digital_rules, test_output
  * Code-Beispiele für jeden Service

- FAQ.md: 40+ häufige Fragen beantwortet (6.3 KB)
  * Allgemein, Installation, Funktionen
  * Fehlersuche, Performance, Services
  * Besondere Anwendungen

## Summary by Sourcery

Add a comprehensive German-language wiki for the Violet Pool Controller Home Assistant integration, covering installation, usage, automation services, troubleshooting, and FAQs.

Documentation:
- Introduce a README-style wiki index with quick links and usage scenarios for the Violet Pool Controller integration.
- Document installation and setup steps including HACS/manual installation, initial configuration, and first automations.
- Explain the controller’s 7 device states (0–6), their semantics, visualisation in Home Assistant, and how to use them in automations.
- Describe all exposed services (e.g. control_pump, smart_dosing, manage_pv_surplus, DMX and diagnostic services) with parameters and YAML examples.
- Add an extensive FAQ and troubleshooting guide for common connectivity, SSL, performance, sensor, and controller issues, including logging and support instructions.