### PR TITLE
fix: correct 3 bugs in config_flow_utils and device after refactor

### DIFF
--- a/custom_components/violet_pool_controller/config_flow_utils/validators.py
+++ b/custom_components/violet_pool_controller/config_flow_utils/validators.py
@@ -3,7 +3,6 @@
 import ipaddress
 import logging
 import re
-from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,20 +30,20 @@ def validate_ip_address(ip: str) -> bool:
         return bool(re.match(r"^[a-zA-Z0-9\-\.]+$", ip))
 
 
-def get_sensor_label(key: str, all_sensors: dict[str, Any]) -> str:
+def get_sensor_label(key: str) -> str:
     """
     Get the friendly name for a sensor key.
 
+    Converts raw sensor keys (e.g. 'PUMP_RPM') to a human-readable label
+    by replacing underscores with spaces and title-casing the result.
+
     Args:
         key: The sensor key.
-        all_sensors: Dictionary of all sensors.
 
     Returns:
-        The friendly name with key.
+        The friendly label for the sensor key.
     """
-    if key in all_sensors:
-        return f"{all_sensors[key]['name']} ({key})"
-    return key
+    return key.replace("_", " ").title()
 
 
 def validate_credentials_strength(username: str | None, password: str | None) -> None:

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -366,8 +366,8 @@ class VioletPoolControllerDevice:
                         self._firmware_version = str(candidate).strip()
                         break
 
-                # Debug-Log nur wenn Firmware gefunden wurde und sich geändert hat
-                if self._firmware_version and not hasattr(self, "_fw_logged"):
+                # Debug-Log nur wenn Firmware gefunden wurde und noch nicht geloggt
+                if self._firmware_version and not self._fw_logged:
                     _LOGGER.debug(
                         "Firmware-Version erkannt: %s", self._firmware_version
                     )
@@ -625,6 +625,9 @@ class VioletPoolControllerDevice:
                 _LOGGER.info("Recovery successful for '%s'", self.device_name)
                 return True
 
+            # Recovery attempt failed (no valid data returned)
+            async with self._recovery_lock:
+                self._recovery_failure_count += 1  # ✅ DIAGNOSTIC: Track failure
             return False
 
         except Exception as err:
@@ -633,6 +636,8 @@ class VioletPoolControllerDevice:
                 current_attempt,
                 err,
             )
+            async with self._recovery_lock:
+                self._recovery_failure_count += 1  # ✅ DIAGNOSTIC: Track failure
             return False
 
         finally:


### PR DESCRIPTION
- validators.py: fix get_sensor_label() signature - was requiring
  `all_sensors` dict but all callers in config_flow.py pass only the
  key; simplified to derive label from key via title-casing

- device.py: fix firmware version logging - hasattr(self, "_fw_logged")
  always returned True since _fw_logged is initialized in __init__;
  changed to `not self._fw_logged` so the debug log fires correctly

- device.py: fix _recovery_failure_count never incremented in
  _attempt_recovery() - both the "no data" and exception failure paths
  now increment the counter so recovery_success_rate returns accurate
  values instead of always 100%

https://claude.ai/code/session_01BJbML6HL6QcX36zxEA2Rfs

## Summary by Sourcery

Fix sensor label derivation and correct device firmware logging and recovery diagnostics.

Bug Fixes:
- Simplify sensor label generation to derive a human-readable label directly from the sensor key instead of requiring the full sensors dictionary.
- Ensure firmware version debug logging only occurs once after a firmware version is detected by tracking an internal logged flag correctly.
- Increment the device recovery failure counter for both no-data and exception paths so recovery success metrics reflect actual failures.