### PR TITLE
Fix stuck sensors by replacing device data on update

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -345,13 +345,7 @@ class VioletPoolControllerDevice:
 
                 # ✅ FIX: Always replace _data with a fresh dict to ensure
                 # HA's DataUpdateCoordinator detects the change.
-                # Merge existing keys that might not be in the new response.
-                if self._data:
-                    merged = dict(self._data)
-                    merged.update(data)
-                    self._data = merged
-                else:
-                    self._data = dict(data)
+                self._data = dict(data)
                 self._available = True
                 self._consecutive_failures = 0
                 self._last_error = None


### PR DESCRIPTION
This PR fixes an issue where sensors would get stuck at old values if the controller API returned partial data.

**Changes:**
- Modified `VioletPoolControllerDevice.async_update` in `custom_components/violet_pool_controller/device.py` to replace `self._data` with the new data instead of merging it.

**Verification:**
- Added a reproduction test case `tests/test_reproduction.py` (deleted before submission) which confirmed that merging caused stuck values and replacing fixes it.
- Ran all existing tests (`tests/`) and they passed.


---
*PR created automatically by Jules for task [9054335546783054230](https://jules.google.com/task/9054335546783054230) started by @Xerolux*

## Summary by Sourcery

Bug Fixes:
- Prevent sensors from getting stuck with stale values by replacing cached device data with the latest API response instead of merging with previous data.