### PR TITLE
fix: services.yaml YAML error and optimistic cache leak on task cance…

### DIFF
--- a/custom_components/violet_pool_controller/climate.py
+++ b/custom_components/violet_pool_controller/climate.py
@@ -379,46 +379,31 @@ class VioletClimateEntity(VioletPoolControllerEntity, ClimateEntity):
         ✅ SHARED CODE: Uses base _request_coordinator_refresh method.
         """
         # ✅ SHARED CODE: Use base refresh method
-        success = await self._request_coordinator_refresh(
-            delay=REFRESH_DELAY, log_context=self.climate_type
-        )
-
-        # Reset optimistische Cache-Werte nach erfolgreichem Refresh
-        if success:
-            old_optimistic_temp = self._optimistic_target_temp
-            old_optimistic_mode = self._optimistic_hvac_mode
-
-            self._optimistic_target_temp = None
-            self._optimistic_hvac_mode = None
-
-            if old_optimistic_temp is not None or old_optimistic_mode is not None:
-                _LOGGER.debug(
-                    "Optimistische Cache-Werte nach Refresh gelöscht "
-                    "(temp: %s, mode: %s)",
-                    old_optimistic_temp,
-                    old_optimistic_mode,
-                )
-
-            # Log neuen State
+        try:
+            await self._request_coordinator_refresh(
+                delay=REFRESH_DELAY, log_context=self.climate_type
+            )
             if self.coordinator.data is not None:
-                new_state = self.coordinator.data.get(self.climate_type, "UNKNOWN")
-                new_temp = self.coordinator.data.get(
-                    f"{self.climate_type}_TARGET_TEMP", "UNKNOWN"
-                )
                 _LOGGER.debug(
                     "State nach Refresh: %s=%s, Target=%s",
                     self.climate_type,
-                    new_state,
-                    new_temp,
+                    self.coordinator.data.get(self.climate_type, "UNKNOWN"),
+                    self.coordinator.data.get(
+                        f"{self.climate_type}_TARGET_TEMP", "UNKNOWN"
+                    ),
                 )
-            else:
-                _LOGGER.debug(
-                    "Coordinator data is None nach Refresh für %s", self.climate_type
-                )
-        else:
-            # Bei Fehler auch Cache löschen
+        finally:
+            # Always clear optimistic caches — even on CancelledError during HA reload
+            old_temp = self._optimistic_target_temp
+            old_mode = self._optimistic_hvac_mode
             self._optimistic_target_temp = None
             self._optimistic_hvac_mode = None
+            if old_temp is not None or old_mode is not None:
+                _LOGGER.debug(
+                    "Optimistische Cache-Werte gelöscht (temp: %s, mode: %s)",
+                    old_temp,
+                    old_mode,
+                )
 
     def _handle_refresh_error(self, task: asyncio.Task) -> None:
         """

--- a/custom_components/violet_pool_controller/entity.py
+++ b/custom_components/violet_pool_controller/entity.py
@@ -299,6 +299,8 @@ class VioletPoolControllerEntity(CoordinatorEntity):
             await asyncio.sleep(delay)
             await self.coordinator.async_request_refresh()
             return self.coordinator.last_update_success
+        except asyncio.CancelledError:
+            raise  # Never swallow CancelledError - propagate task cancellation
         except Exception as err:
             if log_context:
                 _LOGGER.debug(

--- a/custom_components/violet_pool_controller/select.py
+++ b/custom_components/violet_pool_controller/select.py
@@ -263,24 +263,20 @@ class VioletSelect(VioletPoolControllerEntity, SelectEntity):
         ✅ SHARED CODE: Uses base _request_coordinator_refresh method.
         """
         # ✅ SHARED CODE: Use base refresh method
-        success = await self._request_coordinator_refresh(
-            delay=REFRESH_DELAY, log_context=self._device_key
-        )
-
-        # Reset optimistic cache nach erfolgreichem Refresh
-        if success:
+        try:
+            await self._request_coordinator_refresh(
+                delay=REFRESH_DELAY, log_context=self._device_key
+            )
+        finally:
+            # Always clear optimistic cache — even on CancelledError during HA reload
             old_mode = self._optimistic_mode
             self._optimistic_mode = None
-
             if old_mode is not None:
                 _LOGGER.debug(
-                    "Optimistischer Cache nach Refresh gelöscht für %s (war: %s)",
+                    "Optimistischer Cache gelöscht für %s (war: %s)",
                     self._device_key,
                     old_mode,
                 )
-        else:
-            # Bei Fehler auch Cache löschen
-            self._optimistic_mode = None
 
     def _handle_refresh_error(self, task: asyncio.Task) -> None:
         """

--- a/custom_components/violet_pool_controller/services.yaml
+++ b/custom_components/violet_pool_controller/services.yaml
@@ -36,13 +36,13 @@ smart_dosing:
   description: Manual or automatic dosing control
   fields:
     dosing_type:
-      description: Type of dosing
+      description: Type of dosing chemical
       required: true
       selector:
         select:
           options:
-            - pH-
-            - pH+
+            - "pH-"
+            - "pH+"
             - Chlor
             - Flockmittel
     action:
@@ -63,7 +63,7 @@ smart_dosing:
           max: 300
           unit_of_measurement: s
     safety_override:
-      description: Override safety interval
+      description: Override safety interval between dosing cycles
       default: false
       selector:
         boolean:
@@ -106,7 +106,7 @@ control_dmx_scenes:
             - sequence
             - party_mode
     sequence_delay:
-      description: Delay between scenes in sequence mode
+      description: Delay between scenes in sequence mode (seconds)
       default: 2
       selector:
         number:
@@ -116,7 +116,7 @@ control_dmx_scenes:
 
 set_light_color_pulse:
   name: Light Color Pulse
-  description: Send color pulse to pool lighting
+  description: Send color pulse command to pool lighting
   fields:
     pulse_count:
       description: Number of color pulses
@@ -136,7 +136,7 @@ set_light_color_pulse:
 
 manage_digital_rules:
   name: Digital Rules Management
-  description: Manage digital input rules
+  description: Manage digital input automation rules
   fields:
     rule_key:
       description: Rule to manage
@@ -172,19 +172,19 @@ test_output:
         device:
           integration: violet_pool_controller
     output:
-      description: Output identifier (e.g. PUMP, HEATER, SOLAR)
+      description: "Output identifier (e.g. PUMP, HEATER, SOLAR)"
       required: true
       selector:
         text:
     mode:
-      description: Test mode (switch toggles, on forces on, off forces off)
+      description: "Test mode: SWITCH toggles, ON forces on, OFF forces off"
       default: SWITCH
       selector:
         select:
           options:
             - SWITCH
-            - 'ON'
-            - 'OFF'
+            - "ON"
+            - "OFF"
     duration:
       description: Test duration in seconds
       default: 120

--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -469,31 +469,24 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
             key: The switch key.
         """
         # ✅ SHARED CODE: Use base refresh method
-        success = await self._request_coordinator_refresh(
-            delay=REFRESH_DELAY, log_context=key
-        )
+        try:
+            success = await self._request_coordinator_refresh(
+                delay=REFRESH_DELAY, log_context=key
+            )
 
-        # Reset optimistischen Cache nach erfolgreichem Refresh
-        if success:
+            if success and self.coordinator.data is not None:
+                new_state = self.coordinator.data.get(key, "UNKNOWN")
+                _LOGGER.debug("State nach Refresh: %s = %s", key, new_state)
+        finally:
+            # Always clear optimistic cache — even on CancelledError during HA reload
             old_optimistic = self._optimistic_state
             self._optimistic_state = None
-
             if old_optimistic is not None:
                 _LOGGER.debug(
-                    "Optimistischer Cache nach Refresh gelöscht für %s (war: %s)",
+                    "Optimistischer Cache gelöscht für %s (war: %s)",
                     key,
                     "ON" if old_optimistic else "OFF",
                 )
-
-            # Log neuen State (nur bei Debug)
-            if self.coordinator.data is not None:
-                new_state = self.coordinator.data.get(key, "UNKNOWN")
-                _LOGGER.debug("State nach Refresh: %s = %s", key, new_state)
-            else:
-                _LOGGER.debug("Coordinator data is None nach Refresh für %s", key)
-        else:
-            # Bei Fehler auch Cache löschen
-            self._optimistic_state = None
 
     def _handle_refresh_error(self, task: asyncio.Task, key: str) -> None:
         """


### PR DESCRIPTION
fix: services.yaml YAML error and optimistic cache leak on task cance…

## Summary by Sourcery

Ensure coordinator refresh cancellations are propagated and optimistic caches are always cleared, and fix YAML service definitions for the violet_pool_controller integration.

Bug Fixes:
- Prevent stale optimistic climate, switch, and select state by always clearing optimistic caches even when refresh tasks are cancelled or fail.
- Propagate asyncio.CancelledError from coordinator refresh requests instead of swallowing task cancellations.
- Correct invalid YAML in services.yaml by quoting special-string options and tightening service field descriptions.

Enhancements:
- Improve debug logging around post-refresh coordinator state and optimistic cache resets across climate, switch, and select entities.

Documentation:
- Clarify Home Assistant service descriptions and parameter meanings in services.yaml for dosing, lighting, DMX scenes, digital rules, and output testing.