### PR TITLE
 Correct 4 bugs found after config-flow and device refactor

### DIFF
--- a/custom_components/violet_pool_controller/config_flow_utils/validators.py
+++ b/custom_components/violet_pool_controller/config_flow_utils/validators.py
@@ -31,18 +31,18 @@ def validate_ip_address(ip: str) -> bool:
         return bool(re.match(r"^[a-zA-Z0-9\-\.]+$", ip))
 
 
-def get_sensor_label(key: str, all_sensors: dict[str, Any]) -> str:
+def get_sensor_label(key: str, all_sensors: dict[str, Any] | None = None) -> str:
     """
     Get the friendly name for a sensor key.
 
     Args:
         key: The sensor key.
-        all_sensors: Dictionary of all sensors.
+        all_sensors: Optional dictionary of all sensors for friendly name lookup.
 
     Returns:
         The friendly name with key.
     """
-    if key in all_sensors:
+    if all_sensors and key in all_sensors:
         return f"{all_sensors[key]['name']} ({key})"
     return key
 

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -366,8 +366,8 @@ class VioletPoolControllerDevice:
                         self._firmware_version = str(candidate).strip()
                         break
 
-                # Debug-Log nur wenn Firmware gefunden wurde und sich geändert hat
-                if self._firmware_version and not hasattr(self, "_fw_logged"):
+                # Debug-Log nur wenn Firmware gefunden wurde und noch nicht geloggt
+                if self._firmware_version and not self._fw_logged:
                     _LOGGER.debug(
                         "Firmware-Version erkannt: %s", self._firmware_version
                     )
@@ -625,6 +625,8 @@ class VioletPoolControllerDevice:
                 _LOGGER.info("Recovery successful for '%s'", self.device_name)
                 return True
 
+            async with self._recovery_lock:
+                self._recovery_failure_count += 1  # Track failed recovery
             return False
 
         except Exception as err:
@@ -633,6 +635,8 @@ class VioletPoolControllerDevice:
                 current_attempt,
                 err,
             )
+            async with self._recovery_lock:
+                self._recovery_failure_count += 1  # Track failed recovery
             return False
 
         finally:
@@ -669,10 +673,6 @@ class VioletPoolControllerDevice:
         """
         # Clean up any existing task before starting a new one
         await self._cleanup_recovery_task()
-
-        if self._recovery_task and not self._recovery_task.done():
-            _LOGGER.debug("Recovery-Task läuft bereits")
-            return
 
         if self._recovery_attempts >= RECOVERY_MAX_ATTEMPTS:
             _LOGGER.warning(


### PR DESCRIPTION
- config_flow_utils/validators.py: Make `all_sensors` optional (default None) in `get_sensor_label()` — was called with 1 arg everywhere but required 2, causing TypeError crash when sensor selection UI was opened

- device.py: Fix `_fw_logged` check — `hasattr(self, "_fw_logged")` was always True because the attribute is initialized in __init__, so firmware debug log was never emitted; changed to `not self._fw_logged`

- device.py: Increment `_recovery_failure_count` when `_attempt_recovery()` fails — counter stayed 0 forever, making `recovery_success_rate` always return 100% regardless of actual failures

- device.py: Remove dead code in `_start_recovery_background_task` — the `if self._recovery_task and not self._recovery_task.done()` check after `_cleanup_recovery_task()` was always False and unreachable

## Summary by Sourcery

Fix multiple post-refactor bugs in device recovery tracking, firmware logging, and config-flow sensor label handling.

Bug Fixes:
- Ensure firmware debug logging runs only once per detected firmware version instead of being permanently suppressed.
- Correct recovery failure tracking by incrementing the failure counter on each unsuccessful recovery attempt, including exceptions.
- Prevent config-flow crashes by making the sensor registry parameter optional in the sensor label helper and handling the None case safely.

Enhancements:
- Remove unreachable recovery-task guard code from the background recovery starter for clearer control flow.