### PR TITLE
Fix log spam in contact sensor state class override

### DIFF
--- a/custom_components/violet_pool_controller/sensor_modules/generic.py
+++ b/custom_components/violet_pool_controller/sensor_modules/generic.py
@@ -64,10 +64,12 @@ class VioletSensor(VioletPoolControllerEntity, SensorEntity):
         """
         # Force state_class to None for contact sensors
         if "contact" in self.entity_description.key.lower():
-            _LOGGER.debug(
-                "Overriding state_class to None for contact sensor: %s",
-                self.entity_description.key,
-            )
+            # Only log if we're actually overriding a non-None value
+            if self.entity_description.state_class is not None:
+                _LOGGER.debug(
+                    "Overriding state_class to None for contact sensor: %s",
+                    self.entity_description.key,
+                )
             return None
         return self.entity_description.state_class
 

--- a/tests/test_sensor_generic.py
+++ b/tests/test_sensor_generic.py
@@ -1,0 +1,66 @@
+"""Tests for generic sensor modules."""
+from unittest.mock import MagicMock
+import logging
+
+from homeassistant.components.sensor import SensorEntityDescription, SensorStateClass
+
+from custom_components.violet_pool_controller.sensor_modules.generic import VioletSensor
+
+async def test_violet_sensor_state_class_log_spam(hass, caplog):
+    """Test that retrieving state_class for contact sensor does not spam logs."""
+
+    # Mock coordinator
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.device.available = True
+    coordinator.last_update_success = True
+    # device_info is needed by Entity
+    coordinator.device.device_info = {}
+
+    # Mock config entry
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry_id"
+    config_entry.options.get.return_value = False # FORCE_UPDATE default
+    config_entry.data.get.return_value = False # fallback
+
+    # Create description for a contact sensor
+    description = SensorEntityDescription(
+        key="CLOSE_CONTACT",
+        name="Close Contact",
+        state_class=None,
+        translation_key=None
+    )
+
+    # Instantiate sensor
+    sensor = VioletSensor(coordinator, config_entry, description)
+    # Manually add hass to entity (usually done by add_entities)
+    sensor.hass = hass
+
+    # Check logs
+    with caplog.at_level(logging.DEBUG):
+        caplog.clear()
+        _ = sensor.state_class
+
+    log_messages = [r.message for r in caplog.records]
+    log_present = any("Overriding state_class to None for contact sensor: CLOSE_CONTACT" in msg for msg in log_messages)
+
+    assert not log_present, "Log spam should be gone when state_class is already None"
+
+    # Verify safeguard still works
+    description_bad = SensorEntityDescription(
+        key="CLOSE_CONTACT_BAD",
+        name="Close Contact Bad",
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key=None
+    )
+    sensor_bad = VioletSensor(coordinator, config_entry, description_bad)
+    sensor_bad.hass = hass
+
+    with caplog.at_level(logging.DEBUG):
+        caplog.clear()
+        _ = sensor_bad.state_class
+
+    log_messages_bad = [r.message for r in caplog.records]
+    log_present_bad = any("Overriding state_class to None for contact sensor: CLOSE_CONTACT_BAD" in msg for msg in log_messages_bad)
+
+    assert log_present_bad, "Log should appear when safeguard overrides an incorrect state_class"


### PR DESCRIPTION
This change eliminates the frequent debug log message "Overriding state_class to None for contact sensor..." which was appearing on every state update for contact sensors.

The logic in `custom_components/violet_pool_controller/sensor_modules/generic.py` was updated to check if `state_class` is already `None` before logging the override message. Since `state_class` is typically initialized to `None` for contact sensors in the factory method, the override and the log are usually redundant. The safeguard remains in place for edge cases where `state_class` might be incorrectly set.

A new test file `tests/test_sensor_generic.py` was added to verify:
1. No log spam occurs for correctly configured contact sensors.
2. The log message (and safeguard) still works if a contact sensor is incorrectly configured with a numeric state class.

---
*PR created automatically by Jules for task [7868773693810997693](https://jules.google.com/task/7868773693810997693) started by @Xerolux*

## Summary by Sourcery

Prevent unnecessary debug logging when determining state_class for contact sensors and add tests to cover the new behavior.

Bug Fixes:
- Avoid repeatedly logging state_class override messages for correctly configured contact sensors while still enforcing the None state_class override.

Tests:
- Add tests ensuring no debug log is emitted when a contact sensor already has a None state_class and that a log is emitted when an incorrect numeric state_class is overridden.