### PR TITLE
Refactor recovery logic and enable API retries

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -78,29 +78,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return False
 
 
-async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
-    """Set up integration via YAML (deprecated).
-
-    Args:
-        hass: The Home Assistant instance.
-        config: The configuration dictionary.
-
-    Returns:
-        True.
-    """
-    if DOMAIN in config:
-        _LOGGER.warning(
-            "YAML configuration for %s is deprecated and will be removed in a future version. "
-            "Please use the UI to configure the integration.",
-            DOMAIN,
-        )
-
-    # Initialize domain data if not present
-    hass.data.setdefault(DOMAIN, {})
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Violet Pool Controller from a config entry.
 
@@ -215,15 +192,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # NOTE: Do NOT close the aiohttp session - it's managed by Home Assistant!
                 # The session is created by HA via async_get_clientsession() and should only be closed by HA
                 _LOGGER.debug("API object reference released for entry_id=%s", entry.entry_id)
-
-            # Cancel any pending recovery tasks
-            if coordinator and hasattr(coordinator.device, "_recovery_task"):
-                recovery_task = coordinator.device._recovery_task
-                if recovery_task and not recovery_task.done():
-                    recovery_task.cancel()
-                    _LOGGER.debug(
-                        "Recovery task cancelled for entry_id=%s", entry.entry_id
-                    )
 
             # Remove coordinator from hass.data
             if entry.entry_id in hass.data.get(DOMAIN, {}):

--- a/custom_components/violet_pool_controller/api.py
+++ b/custom_components/violet_pool_controller/api.py
@@ -244,6 +244,10 @@ class VioletPoolAPI:
                         timeout=self._timeout,
                         ssl=self._ssl_context,
                     ) as response:
+                        if response.status >= 500 or response.status == 429:
+                            # Server error or rate limit -> trigger retry via ClientError
+                            response.raise_for_status()
+
                         if response.status >= 400:
                             body = await response.text()
                             raise VioletPoolAPIError(

--- a/custom_components/violet_pool_controller/binary_sensor.py
+++ b/custom_components/violet_pool_controller/binary_sensor.py
@@ -1,4 +1,6 @@
+
 """Binary Sensor Integration für den Violet Pool Controller - OPTIMIZED VERSION."""
+from __future__ import annotations
 
 import logging
 from typing import Any

--- a/custom_components/violet_pool_controller/circuit_breaker.py
+++ b/custom_components/violet_pool_controller/circuit_breaker.py
@@ -1,4 +1,6 @@
+
 """Circuit breaker implementation for resilient API calls."""
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/violet_pool_controller/climate.py
+++ b/custom_components/violet_pool_controller/climate.py
@@ -1,4 +1,6 @@
+
 """Climate Integration für den Violet Pool Controller - FULLY PROTECTED & THREAD-SAFE VERSION."""
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -1,3 +1,4 @@
+
 """This module serves as the central hub for all constants in the Violet Pool Controller integration.
 
 It aggregates constants from specialized modules (`const_api`, `const_devices`,
@@ -8,6 +9,7 @@ by organizing constants based on their functional area.
 The module also defines core integration-level information, such as the domain,
 version, and manufacturer details, as well as configuration keys and default values.
 """
+from __future__ import annotations
 
 # flake8: noqa: F401, F403 - Allows central exporting of constants
 # ruff: noqa: F401, F403 - Allows central exporting of constants

--- a/custom_components/violet_pool_controller/const_api.py
+++ b/custom_components/violet_pool_controller/const_api.py
@@ -1,3 +1,4 @@
+
 """This module defines constants related to the Violet Pool Controller API.
 
 It includes API endpoints, command actions, rate limiting settings, and
@@ -5,6 +6,7 @@ definitions for various controllable functions like switches, covers, and dosing
 These constants provide a centralized and consistent way to interact with the
 controller's HTTP API.
 """
+from __future__ import annotations
 
 # =============================================================================
 # API ENDPOINTS

--- a/custom_components/violet_pool_controller/const_devices.py
+++ b/custom_components/violet_pool_controller/const_devices.py
@@ -1,3 +1,4 @@
+
 """This module defines constants related to device characteristics and states.
 
 It includes detailed parameter configurations for various devices (e.g., pumps, heaters),
@@ -5,6 +6,7 @@ state mappings for normalizing device statuses, and visual configurations like i
 and colors. The module also provides helper functions and a `VioletState` class to
 consistently interpret and manage device states throughout the integration.
 """
+from __future__ import annotations
 
 from typing import Any, Dict, Optional, cast
 

--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -1,3 +1,4 @@
+
 """This module defines the features and entities available in the integration.
 
 It includes a list of all toggleable features that can be configured by the user,
@@ -5,6 +6,7 @@ as well as detailed definitions for binary sensors, switches, and number entitie
 (setpoints). These definitions are used to dynamically create the correct entities
 based on the user's enabled features and the data available from the controller.
 """
+from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass

--- a/custom_components/violet_pool_controller/const_sensors.py
+++ b/custom_components/violet_pool_controller/const_sensors.py
@@ -1,3 +1,4 @@
+
 """This module defines constants related to sensor entities.
 
 It includes definitions for different categories of sensors such as temperature,
@@ -5,6 +6,7 @@ water chemistry, and system diagnostics. It also provides unit mappings and
 mappings between sensor keys and integration features to control sensor creation
 based on user configuration.
 """
+from __future__ import annotations
 
 # =============================================================================
 # SENSOR DEFINITIONS

--- a/custom_components/violet_pool_controller/cover.py
+++ b/custom_components/violet_pool_controller/cover.py
@@ -1,4 +1,6 @@
+
 """Cover Integration für den Violet Pool Controller."""
+from __future__ import annotations
 
 import logging
 

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -34,29 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 # ✅ LOGGING OPTIMIZATION: Throttling-Konstanten
 FAILURE_LOG_INTERVAL = 300  # Nur alle 5 Minuten bei wiederholten Fehlern
 
-# ✅ RECOVERY OPTIMIZATION: Auto-Recovery-Konstanten
-RECOVERY_MAX_ATTEMPTS = 10  # Maximale Recovery-Versuche
-RECOVERY_BASE_DELAY = 10.0  # Basis-Delay für Exponential Backoff (10s)
-RECOVERY_MAX_DELAY = 300.0  # Maximaler Delay zwischen Versuchen (5 Min)
-
-# =============================================================================
-# THREAD SAFETY & LOCK ORDERING
-# =============================================================================
-# To prevent deadlocks, ALWAYS acquire locks in this order:
-# 1. _api_lock - protects API calls and data updates
-# 2. _recovery_lock - protects recovery state and attempts
-#
-# NEVER:
-# - Acquire _recovery_lock while holding _api_lock
-# - Acquire _api_lock while holding _recovery_lock
-# - Nest locks without releasing the first one
-#
-# SAFE PATTERNS:
-# - async with self._api_lock: ... (standalone)
-# - async with self._recovery_lock: ... (standalone)
-# - If both needed: acquire one, release, then acquire the other
-# =============================================================================
-
 
 class VioletPoolControllerDevice:
     """Violet Pool Controller Device - SMART LOGGING + AUTO RECOVERY."""
@@ -64,7 +41,7 @@ class VioletPoolControllerDevice:
     def __init__(
         self, hass: HomeAssistant, config_entry: ConfigEntry, api: VioletPoolAPI
     ) -> None:
-        """Initialisiere die Geräteinstanz mit Smart Logging und Auto-Recovery."""
+        """Initialisiere die Geräteinstanz mit Smart Logging."""
         self.hass = hass
         self.config_entry = config_entry
         self.api = api
@@ -84,13 +61,6 @@ class VioletPoolControllerDevice:
         self._recovery_logged = False  # Flag für Recovery-Message
         self._fw_logged = False  # Flag für Firmware-Version-Logging
 
-        # ✅ RECOVERY OPTIMIZATION: Auto-Recovery Tracking
-        self._recovery_attempts = 0  # Zähler für Recovery-Versuche
-        self._in_recovery_mode = False  # Flag für Recovery-Modus
-        self._last_recovery_attempt = 0.0  # Timestamp letzter Recovery-Versuch
-        self._recovery_task: asyncio.Task | None = None  # Recovery-Task
-        self._recovery_lock = asyncio.Lock()  # ✅ Lock für thread-safe Recovery
-
         # ✅ DIAGNOSTIC SENSORS: Connection health monitoring
         self._last_update_time = 0.0  # Timestamp of last successful update
         self._connection_latency = 0.0  # Last connection latency in milliseconds
@@ -102,8 +72,6 @@ class VioletPoolControllerDevice:
         self._latency_history: list[
             float
         ] = []  # Rolling window for average latency (max 60 samples)
-        self._recovery_success_count = 0  # Successful recoveries
-        self._recovery_failure_count = 0  # Failed recoveries
 
         # Konfiguration extrahieren (mit Options-Support)
         entry_data = config_entry.data
@@ -325,18 +293,15 @@ class VioletPoolControllerDevice:
                         # Kritisch: Wird unavailable - IMMER loggen
                         _LOGGER.error(
                             "Controller '%s' nach %d aufeinanderfolgenden Fehlern als "
-                            "unavailable markiert. Starte Auto-Recovery...",
+                            "unavailable markiert.",
                             self.device_name,
                             self._consecutive_failures,
                         )
                         self._available = False
 
-                        # ✅ RECOVERY: Start automatic recovery
-                        await self._start_recovery_background_task()
-
                         raise UpdateFailed(
                             f"Controller '{self.device_name}' nicht erreichbar "
-                            f"({self._consecutive_failures} Fehler), Recovery gestartet"
+                            f"({self._consecutive_failures} Fehler)"
                         )
 
                     elif self._should_log_failure():
@@ -626,173 +591,6 @@ class VioletPoolControllerDevice:
         if not self._latency_history:
             return 0.0
         return sum(self._latency_history) / len(self._latency_history)
-
-    @property
-    def recovery_success_rate(self) -> float:
-        """
-        Return recovery success rate as percentage (0-100).
-
-        ✅ DIAGNOSTIC SENSOR: Recovery effectiveness.
-        """
-        total = self._recovery_success_count + self._recovery_failure_count
-        if total == 0:
-            return 100.0  # No recovery attempts = 100% success
-        return (self._recovery_success_count / total) * 100
-
-    async def _attempt_recovery(self) -> bool:
-        """
-        Attempt automatic connection recovery.
-
-        ✅ RECOVERY OPTIMIZATION:
-        - Exponential backoff for recovery attempts.
-        - Thread-safe with asyncio.Lock (Race Condition Fix).
-
-        Returns:
-            True if recovery was successful, False otherwise.
-        """
-        # ✅ RACE CONDITION FIX: Complete atomic recovery with proper lock protection
-        async with self._recovery_lock:
-            # Atomic check-and-set under same lock
-            if self._in_recovery_mode:
-                _LOGGER.debug("Recovery bereits im Gange, überspringe")
-                return False
-
-            if self._recovery_attempts > RECOVERY_MAX_ATTEMPTS:
-                _LOGGER.warning("Maximum recovery attempts reached")
-                return False
-
-            # Set recovery state atomically
-            self._in_recovery_mode = True
-            self._recovery_attempts += 1
-            current_attempt = self._recovery_attempts
-
-        try:
-            # Calculate exponential backoff delay
-            delay = min(
-                RECOVERY_MAX_DELAY,
-                RECOVERY_BASE_DELAY * (2 ** (current_attempt - 1)),
-            )
-
-            _LOGGER.info(
-                "🔄 Recovery-Versuch %d/%d für '%s' (Delay: %.1fs)",
-                current_attempt,
-                RECOVERY_MAX_ATTEMPTS,
-                self.device_name,
-                delay,
-            )
-
-            await asyncio.sleep(delay)
-
-            # Attempt data retrieval under _api_lock to prevent concurrent API calls.
-            # Lock ordering: _api_lock first, _recovery_lock second — never nest them.
-            # We are NOT holding _recovery_lock here, so acquiring _api_lock is safe.
-            async with self._api_lock:
-                data = await self._fetch_controller_data()
-
-            if data and isinstance(data, dict):
-                # Recovery successful - merge data and reset state atomically
-                async with self._recovery_lock:
-                    # ✅ FIX: Store recovered data so entities update immediately
-                    # without waiting for the next normal coordinator poll cycle.
-                    if self._data:
-                        merged = dict(self._data)
-                        merged.update(data)
-                        self._data = merged
-                    else:
-                        self._data = dict(data)
-                    self._consecutive_failures = 0
-                    self._recovery_attempts = 0
-                    self._available = True
-                    self._recovery_logged = True
-                    self._recovery_success_count += 1  # ✅ DIAGNOSTIC: Track success
-
-                _LOGGER.info("Recovery successful for '%s'", self.device_name)
-                return True
-
-            # Recovery attempt failed (no valid data returned)
-            async with self._recovery_lock:
-                self._recovery_failure_count += 1  # ✅ DIAGNOSTIC: Track failure
-            return False
-
-        except Exception as err:
-            _LOGGER.debug(
-                "Recovery-Versuch %d fehlgeschlagen: %s",
-                current_attempt,
-                err,
-            )
-            async with self._recovery_lock:
-                self._recovery_failure_count += 1  # ✅ DIAGNOSTIC: Track failure
-            return False
-
-        finally:
-            # Always ensure recovery state is reset under lock protection
-            async with self._recovery_lock:
-                self._in_recovery_mode = False
-                self._last_recovery_attempt = time.monotonic()
-
-    async def _cleanup_recovery_task(self) -> None:
-        """
-        Cancel existing recovery task if running.
-
-        ✅ TASK CLEANUP: Ensures old recovery tasks are properly cancelled
-        before starting new ones, preventing resource leaks.
-
-        This should be called before creating a new recovery task to ensure
-        any existing task is properly cancelled.
-        """
-        if self._recovery_task and not self._recovery_task.done():
-            _LOGGER.debug("Cancelling existing recovery task before creating new one")
-            self._recovery_task.cancel()
-            try:
-                await self._recovery_task
-            except asyncio.CancelledError:
-                _LOGGER.debug("Recovery-Task successfully cancelled")
-            except Exception as err:
-                _LOGGER.warning("Error cancelling recovery task: %s", err)
-        self._recovery_task = None
-
-    async def _start_recovery_background_task(self) -> None:
-        """
-        Start recovery in the background.
-
-        ✅ RECOVERY OPTIMIZATION: Prevents blocking normal updates.
-        """
-        # Clean up any existing task before starting a new one
-        await self._cleanup_recovery_task()
-
-        if self._recovery_attempts >= RECOVERY_MAX_ATTEMPTS:
-            _LOGGER.warning(
-                "⚠️ Maximale Recovery-Versuche (%d) erreicht für '%s'. "
-                "Manuelle Intervention erforderlich.",
-                RECOVERY_MAX_ATTEMPTS,
-                self.device_name,
-            )
-            return
-
-        async def recovery_loop() -> None:
-            """Recovery-Loop im Hintergrund."""
-            while self._recovery_attempts < RECOVERY_MAX_ATTEMPTS:
-                if await self._attempt_recovery():
-                    _LOGGER.info(
-                        "✅ Background Recovery erfolgreich für '%s'",
-                        self.device_name,
-                    )
-                    return
-
-                # Warte vor nächstem Versuch
-                await asyncio.sleep(5)
-
-            _LOGGER.error(
-                "❌ Background Recovery fehlgeschlagen für '%s' nach %d Versuchen",
-                self.device_name,
-                RECOVERY_MAX_ATTEMPTS,
-            )
-
-        self._recovery_task = asyncio.create_task(recovery_loop())
-        _LOGGER.info(
-            "🔄 Background Recovery gestartet für '%s'",
-            self.device_name,
-        )
 
     def _extract_api_url(self, entry_data: Mapping[str, Any]) -> str:
         """

--- a/custom_components/violet_pool_controller/error_handler.py
+++ b/custom_components/violet_pool_controller/error_handler.py
@@ -1,4 +1,6 @@
+
 """Error handling consistency improvements for Violet Pool Controller."""
+from __future__ import annotations
 
 import logging
 from typing import Any, Optional

--- a/custom_components/violet_pool_controller/number.py
+++ b/custom_components/violet_pool_controller/number.py
@@ -1,4 +1,6 @@
+
 """Number Integration für den Violet Pool Controller - WITH INPUT SANITIZATION."""
+from __future__ import annotations
 
 import logging
 

--- a/custom_components/violet_pool_controller/select.py
+++ b/custom_components/violet_pool_controller/select.py
@@ -1,4 +1,6 @@
+
 """Select Integration für den Violet Pool Controller - ON/OFF/AUTO Steuerung."""
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/violet_pool_controller/sensor.py
+++ b/custom_components/violet_pool_controller/sensor.py
@@ -37,7 +37,6 @@ from .sensor_modules import (
     VioletErrorCodeSensor,
     VioletFlowRateSensor,
     VioletLastEventAgeSensor,
-    VioletRecoverySuccessRateSensor,
     VioletSensor,
     VioletStatusSensor,
     VioletSystemHealthSensor,
@@ -138,7 +137,6 @@ def _create_special_sensors(
             VioletLastEventAgeSensor(coordinator, config_entry),
             VioletAPIRequestRateSensor(coordinator, config_entry),
             VioletAverageLatencySensor(coordinator, config_entry),
-            VioletRecoverySuccessRateSensor(coordinator, config_entry),
         ]
     )
     handled_keys.update(
@@ -148,12 +146,11 @@ def _create_special_sensors(
             "last_event_age",
             "api_request_rate",
             "average_latency",
-            "recovery_success_rate",
         }
     )
     _LOGGER.debug(
         "Diagnostic sensors created (System Health, Connection Latency, Last Event Age, "
-        "API Request Rate, Average Latency, Recovery Success Rate)"
+        "API Request Rate, Average Latency)"
     )
 
     # Error Code Sensors

--- a/custom_components/violet_pool_controller/sensor_modules/__init__.py
+++ b/custom_components/violet_pool_controller/sensor_modules/__init__.py
@@ -1,4 +1,6 @@
+
 """Sensor Submodules for Violet Pool Controller."""
+from __future__ import annotations
 
 from .base import (
     _BOOLEAN_VALUE_KEYS,

--- a/custom_components/violet_pool_controller/sensor_modules/__init__.py
+++ b/custom_components/violet_pool_controller/sensor_modules/__init__.py
@@ -17,7 +17,6 @@ from .monitoring import (
     VioletAverageLatencySensor,
     VioletConnectionLatencySensor,
     VioletLastEventAgeSensor,
-    VioletRecoverySuccessRateSensor,
     VioletSystemHealthSensor,
 )
 from .specialized import (
@@ -42,7 +41,6 @@ __all__ = [
     "VioletAverageLatencySensor",
     "VioletConnectionLatencySensor",
     "VioletLastEventAgeSensor",
-    "VioletRecoverySuccessRateSensor",
     "VioletSystemHealthSensor",
     # Specialized
     "VioletDosingStateSensor",

--- a/custom_components/violet_pool_controller/sensor_modules/monitoring.py
+++ b/custom_components/violet_pool_controller/sensor_modules/monitoring.py
@@ -167,27 +167,3 @@ class VioletAverageLatencySensor(VioletPoolControllerEntity, SensorEntity):
         return round(self.coordinator.device.average_latency, 0)
 
 
-class VioletRecoverySuccessRateSensor(VioletPoolControllerEntity, SensorEntity):
-    """Sensor for recovery success rate."""
-
-    def __init__(
-        self,
-        coordinator: VioletPoolDataUpdateCoordinator,
-        config_entry: ConfigEntry,
-    ) -> None:
-        """Initialize the recovery success rate sensor."""
-        description = SensorEntityDescription(
-            key="recovery_success_rate",
-            translation_key="recovery_success_rate",
-            name="Recovery Success Rate",
-            icon="mdi:restore",
-            native_unit_of_measurement="%",
-            entity_category=EntityCategory.DIAGNOSTIC,
-            state_class=SensorStateClass.MEASUREMENT,
-        )
-        super().__init__(coordinator, config_entry, description)
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the recovery success rate."""
-        return round(self.coordinator.device.recovery_success_rate, 1)

--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -17,7 +17,7 @@ from typing import Any, Iterable
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -978,7 +978,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
     schemas = get_service_schemas()
 
     # Register services
-    service_map = {
+    # Regular services (no return value)
+    regular_services = {
         "control_pump": handlers.handle_control_pump,
         "smart_dosing": handlers.handle_smart_dosing,
         "manage_pv_surplus": handlers.handle_manage_pv_surplus,
@@ -986,12 +987,23 @@ async def async_register_services(hass: HomeAssistant) -> None:
         "set_light_color_pulse": handlers.handle_set_light_color_pulse,
         "manage_digital_rules": handlers.handle_manage_digital_rules,
         "test_output": handlers.handle_test_output,
-        "export_diagnostic_logs": handlers.handle_export_diagnostic_logs,
     }
 
-    for service_name, handler in service_map.items():
+    for service_name, handler in regular_services.items():
         hass.services.async_register(
             DOMAIN, service_name, handler, schema=schemas.get(service_name)
         )
 
-    _LOGGER.info("Successfully registered %d services", len(service_map))
+    # Services returning data
+    hass.services.async_register(
+        DOMAIN,
+        "export_diagnostic_logs",
+        handlers.handle_export_diagnostic_logs,
+        schema=schemas.get("export_diagnostic_logs"),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    _LOGGER.info(
+        "Successfully registered %d services",
+        len(regular_services) + 1,
+    )

--- a/custom_components/violet_pool_controller/utils_sanitizer.py
+++ b/custom_components/violet_pool_controller/utils_sanitizer.py
@@ -1,4 +1,6 @@
+
 """Input Sanitization Utilities für User-Inputs und API-Parameter."""
+from __future__ import annotations
 
 import logging
 import re

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,14 +115,23 @@ class TestVioletPoolAPI:
         mock_response.status = 500
         mock_response.text = AsyncMock(return_value="Internal Server Error")
 
+        # Ensure raise_for_status raises an exception (sync method)
+        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+             request_info=MagicMock(), history=tuple(), status=500, message="Server Error"
+        )
+
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
         mock_session.request = MagicMock(return_value=mock_response)
 
         with patch.object(api._rate_limiter, 'wait_if_needed', new_callable=AsyncMock):
-            # Sollte VioletPoolAPIError werfen
-            with pytest.raises(VioletPoolAPIError, match="HTTP 500"):
+            # Sollte VioletPoolAPIError werfen (nach Retries)
+            # Hinweis: Der retry loop fängt aiohttp.ClientError (Basis von ClientResponseError)
+            # und wirft am Ende VioletPoolAPIError.
+            # Da wir raise_for_status gemockt haben, wird der Retry Loop ausgelöst.
+            with pytest.raises(VioletPoolAPIError):
                 await api._request("/error")
 
     async def test_json_parsing_error_handling(self, api, mock_session):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,4 @@
-"""Tests for Violet Pool Controller Device with Auto-Recovery."""
+"""Tests for Violet Pool Controller Device."""
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,7 +17,7 @@ from custom_components.violet_pool_controller.device import VioletPoolController
 
 
 class TestVioletPoolControllerDevice:
-    """Test VioletPoolControllerDevice with Recovery."""
+    """Test VioletPoolControllerDevice."""
 
     @pytest.fixture
     def mock_hass(self):
@@ -60,102 +60,6 @@ class TestVioletPoolControllerDevice:
             )
             return device
 
-    async def test_recovery_lock_initialized(self, device):
-        """Test dass Recovery-Lock korrekt initialisiert wird."""
-        assert device._recovery_lock is not None, "Recovery-Lock sollte initialisiert sein"
-        assert isinstance(device._recovery_lock, asyncio.Lock), "Sollte asyncio.Lock sein"
-
-    async def test_recovery_race_condition_prevented(self, device):
-        """Test dass Race Condition bei Recovery verhindert wird."""
-        # Mock _fetch_controller_data
-        device._fetch_controller_data = AsyncMock(return_value={"test": "data"})
-        device._in_recovery_mode = False # Ensure false start
-
-        # Starte zwei Recovery-Versuche parallel
-        # Wir müssen sicherstellen, dass sie "gleichzeitig" den Lock erreichen
-        # Aber asyncio ist single threaded.
-        # Wir können prüfen, ob der zweite sofort returned.
-
-        # Da wir im Test sind, rufen wir _attempt_recovery direkt auf.
-
-        task1 = asyncio.create_task(device._attempt_recovery())
-        task2 = asyncio.create_task(device._attempt_recovery())
-
-        # Beide Tasks ausführen
-        results = await asyncio.gather(task1, task2)
-
-        # Nur einer sollte erfolgreich sein (True), der andere sollte False zurückgeben
-        # (weil bereits im Recovery-Modus oder Lock gehalten)
-        # Wait, if both succeed (because data fetch works), one might return True and other False?
-        # If lock works:
-        # T1 gets lock. Sets in_recovery_mode = True. Releases lock (wait, no).
-        # T1 holds lock, checks in_recovery.
-        # T1 sets in_recovery = True.
-        # T1 releases lock? No, `async with self._recovery_lock:` scope.
-        # The logic in `_attempt_recovery`:
-        # async with self._recovery_lock:
-        #    if self._in_recovery_mode: return False
-        #    self._in_recovery_mode = True
-        # ... do stuff ...
-        # finally: self._in_recovery_mode = False
-
-        # So T1 enters lock, sets flag, EXITS lock.
-        # T2 enters lock, sees flag, returns False.
-        # T1 continues recovery.
-
-        # So yes, one should be True (the one that proceeded), one False.
-
-        assert results.count(True) == 1, f"Nur ein Recovery-Versuch sollte erfolgreich sein, got {results}"
-        assert results.count(False) == 1, "Ein Recovery-Versuch sollte abgelehnt werden"
-
-    async def test_recovery_exponential_backoff(self, device):
-        """Test dass Exponential Backoff korrekt berechnet wird."""
-        device._fetch_controller_data = AsyncMock(return_value={"test": "data"})
-        # We need to ensure we don't actually sleep for real time
-
-        # Erster Versuch
-        device._recovery_attempts = 0
-        device._in_recovery_mode = False
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await device._attempt_recovery()
-            # Erster Versuch: 10s * 2^0 = 10s
-            mock_sleep.assert_called_once()
-            # call_args[0][0] is the first positional arg
-            assert mock_sleep.call_args[0][0] == 10.0
-
-        # Zweiter Versuch
-        device._in_recovery_mode = False
-        device._recovery_attempts = 1
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await device._attempt_recovery()
-            # Zweiter Versuch: 10s * 2^1 = 20s
-            assert mock_sleep.call_args[0][0] == 20.0
-
-        # Fünfter Versuch
-        device._in_recovery_mode = False
-        device._recovery_attempts = 4
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await device._attempt_recovery()
-            # Fünfter Versuch: 10s * 2^4 = 160s
-            assert mock_sleep.call_args[0][0] == 160.0
-
-    async def test_recovery_max_delay_cap(self, device):
-        """Test dass Recovery Delay bei 300s gekappt wird."""
-        device._fetch_controller_data = AsyncMock(return_value={"test": "data"})
-
-        # Sehr hoher Versuch (sollte 10 * 2^10 = 10240s ergeben, aber bei 300s gekappt werden)
-        device._in_recovery_mode = False
-        device._recovery_attempts = 10
-
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await device._attempt_recovery()
-            # Sollte bei 300s (RECOVERY_MAX_DELAY) gekappt sein
-            if mock_sleep.call_args:
-                args, _ = mock_sleep.call_args
-                assert args[0] == 300.0
-            else:
-                 pytest.fail("asyncio.sleep was not called")
-
     async def test_controller_name_in_device_info(self, device):
         """Test dass Controller-Name in device_info verwendet wird."""
         device_info = device.device_info
@@ -176,23 +80,3 @@ class TestVioletPoolControllerDevice:
         updated_info = device.device_info
         assert updated_info["name"] == "Neuer Pool Name"
         assert updated_info["suggested_area"] == "Neuer Pool Name"
-
-    async def test_recovery_success_resets_counters(self, device):
-        """Test dass erfolgreiche Recovery Zähler zurücksetzt."""
-        device._fetch_controller_data = AsyncMock(return_value={"test": "data"})
-        device._consecutive_failures = 5
-        device._recovery_attempts = 3
-        device._in_recovery_mode = False
-
-        # Recovery durchführen
-        # We need to mock sleep to avoid waiting
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await device._attempt_recovery()
-
-        # Sollte erfolgreich sein
-        assert result is True
-
-        # Zähler sollten zurückgesetzt sein
-        assert device._consecutive_failures == 0
-        assert device._recovery_attempts == 0
-        assert device._available is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,6 @@ from homeassistant.exceptions import HomeAssistantError
 from custom_components.violet_pool_controller import (
     PLATFORMS,
     async_migrate_entry,
-    async_setup,
     async_setup_entry,
     async_unload_entry,
 )
@@ -72,16 +71,6 @@ def coordinator() -> MagicMock:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
-
-async def test_async_setup_initialises_domain(hass: HomeAssistant) -> None:
-    # Ensure domain is clean
-    if DOMAIN in hass.data:
-        del hass.data[DOMAIN]
-
-    result = await async_setup(hass, {})
-    assert result is True
-    assert DOMAIN in hass.data
 
 
 async def test_async_setup_entry_success(hass: HomeAssistant, config_entry: MockConfigEntry, coordinator: MagicMock) -> None:


### PR DESCRIPTION
This PR addresses three main points:
1.  **API Robustness:** `api.py` now correctly triggers the retry loop for server errors (5xx) and rate limits (429) instead of failing immediately.
2.  **Simplified Recovery:** `device.py` was refactored to remove the complex custom background recovery task. The integration now relies on Home Assistant's `DataUpdateCoordinator` to handle retries upon `UpdateFailed` exceptions, which is the standard and more robust approach.
3.  **Code Cleanup:** The deprecated `async_setup` function was removed from `__init__.py` to comply with future Home Assistant standards.

Tests were updated to accommodate these changes, specifically removing tests for the custom recovery logic and fixing the API error handling test.

---
*PR created automatically by Jules for task [3009093075663978620](https://jules.google.com/task/3009093075663978620) started by @Xerolux*

## Summary by Sourcery

Refactor the integration’s recovery and error handling to rely on Home Assistant’s standard mechanisms and improve API retry behavior.

Bug Fixes:
- Ensure API requests trigger the retry loop for server (5xx) and rate limit (429) responses instead of failing immediately.

Enhancements:
- Remove the custom background recovery mechanism from the device class in favor of coordinator-driven retries on update failures.
- Drop the recovery success rate diagnostic sensor and its related device metrics to simplify monitoring.
- Clean up the integration unload flow by removing recovery-task cancellation that is no longer needed after removing custom recovery.
- Remove the deprecated YAML-based async_setup entry point to align with current Home Assistant integration standards.

Tests:
- Remove tests tied to the custom recovery logic and adjust API error handling and integration setup tests to match the new behavior.