### PR TITLE
Fix `CoverIsClosedBinarySensor` not respecting `force_update` setting

### DIFF
--- a/custom_components/violet_pool_controller/binary_sensor.py
+++ b/custom_components/violet_pool_controller/binary_sensor.py
@@ -136,7 +136,7 @@ class VioletBinarySensor(VioletPoolControllerEntity, BinarySensorEntity):
         }
 
 
-class CoverIsClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class CoverIsClosedBinarySensor(VioletPoolControllerEntity, BinarySensorEntity):
     """Sensor indicating if the cover is closed."""
 
     def __init__(
@@ -151,26 +151,17 @@ class CoverIsClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
             coordinator: The update coordinator.
             config_entry: The config entry.
         """
-        super().__init__(coordinator)
-        self._attr_has_entity_name = True
-        self._attr_name = "Cover Geschlossen"  # type: ignore[assignment]
-        self._attr_unique_id = f"{config_entry.entry_id}_cover_is_closed"
-        self._attr_device_class = BinarySensorDeviceClass.DOOR
-        self._attr_icon = "mdi:window-shutter"
-        self._attr_device_info = coordinator.device.device_info  # type: ignore[assignment]
+        description = BinarySensorEntityDescription(
+            key="cover_is_closed",
+            name="Cover Geschlossen",
+            device_class=BinarySensorDeviceClass.DOOR,
+            icon="mdi:window-shutter",
+        )
+        super().__init__(coordinator, config_entry, description)
+
         _LOGGER.debug(
             "Initialisiere Cover-Geschlossen Sensor: %s", self._attr_unique_id
         )
-
-    @property
-    def available(self) -> bool:
-        """
-        Return whether the entity is available.
-
-        Returns:
-            True if available, False otherwise.
-        """
-        return self.coordinator.last_update_success
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
Refactored `CoverIsClosedBinarySensor` to inherit from `VioletPoolControllerEntity` instead of `CoordinatorEntity`. This ensures that the "Force Update" configuration option works for this sensor, consistent with all other entities in the integration. Verified with a new test case.

---
*PR created automatically by Jules for task [3250575067364591211](https://jules.google.com/task/3250575067364591211) started by @Xerolux*

## Summary by Sourcery

Ensure the cover-closed binary sensor uses the common VioletPoolController entity base for consistent behavior and configuration handling.

Bug Fixes:
- Make the cover-closed binary sensor respect the integration’s force_update setting like other entities.

Enhancements:
- Refactor the cover-closed binary sensor to use a shared entity description and common VioletPoolControllerEntity base class for metadata and availability handling.