### PR TITLE
Fix export_diagnostic_logs failing with Device not found

### DIFF
--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -19,6 +19,7 @@ import voluptuous as vol
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .api import VioletPoolAPIError
@@ -216,10 +217,23 @@ class VioletServiceManager:
             The coordinator instance or None.
         """
         domain_data = self.hass.data.get(DOMAIN, {})
+
+        # 1. Check if device_id is directly a config_entry_id (legacy/direct usage)
         for coordinator in domain_data.values():
             if hasattr(coordinator, "device") and coordinator.device:
                 if str(coordinator.config_entry.entry_id) == device_id:
                     return coordinator
+
+        # 2. Check if device_id is a device registry ID
+        dev_reg = dr.async_get(self.hass)
+        device = dev_reg.async_get(device_id)
+
+        if device:
+            for config_entry_id in device.config_entries:
+                coordinator = domain_data.get(config_entry_id)
+                if coordinator and hasattr(coordinator, "device") and coordinator.device:
+                    return coordinator
+
         return None
 
     async def get_coordinators_for_entities(self, entity_ids: list[str]) -> list[Any]:
@@ -802,7 +816,7 @@ class VioletServiceHandlers:
 
             await coordinator.async_request_refresh()
 
-    async def handle_export_diagnostic_logs(self, call: ServiceCall) -> None:
+    async def handle_export_diagnostic_logs(self, call: ServiceCall) -> dict[str, Any]:
         """
         Handle the export diagnostic logs service.
 
@@ -921,7 +935,7 @@ Lines: {len(log_entries)}
                     )
 
                     # Also return the content
-                    call.response = {
+                    return {
                         "success": True,
                         "filename": filename,
                         "filepath": filepath,
@@ -939,7 +953,7 @@ Lines: {len(log_entries)}
                     device_name
                 )
 
-                call.response = {
+                return {
                     "success": True,
                     "lines_exported": len(log_entries),
                     "logs": export_text,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,64 @@
+
+import pytest
+from unittest.mock import MagicMock
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.violet_pool_controller.const import DOMAIN
+from custom_components.violet_pool_controller.services import async_register_services
+
+@pytest.mark.asyncio
+async def test_export_diagnostic_logs_failure(hass: HomeAssistant, device_registry: dr.DeviceRegistry):
+    """Test to reproduce the issue where device_id from registry is not found."""
+
+    # 1. Setup Config Entry
+    config_entry = MockConfigEntry(domain=DOMAIN, entry_id="config_entry_123")
+    config_entry.add_to_hass(hass)
+
+    # 2. Setup Device in Registry linked to Config Entry
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "unique_device_id")},
+        name="Test Device"
+    )
+
+    # 3. Mock Coordinator and attach to hass.data
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry = config_entry
+    # Setup mock device inside coordinator
+    mock_coordinator.device = MagicMock()
+    mock_coordinator.device.device_name = "Test Device"
+    mock_coordinator.device.available = True
+    mock_coordinator.device.controller_name = "Violet Pool Controller"
+    mock_coordinator.device.api_url = "http://192.168.1.100"
+    mock_coordinator.device.device_id = "1"
+    mock_coordinator.device.firmware_version = "1.0.0"
+    mock_coordinator.device.last_event_age = 10.0
+    mock_coordinator.device.connection_latency = 50.0
+    mock_coordinator.device.system_health = 100.0
+    mock_coordinator.device._update_counter = 100
+    mock_coordinator.device.consecutive_failures = 0
+
+    hass.data[DOMAIN] = {
+        config_entry.entry_id: mock_coordinator
+    }
+
+    # 4. Register Services
+    await async_register_services(hass)
+
+    # 5. Call Service with Device Registry ID
+    # This is what the UI sends when you select a device.
+    # With the fix, this should now succeed.
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "export_diagnostic_logs",
+        {"device_id": device.id}, # device.id is the registry ID
+        blocking=True,
+        return_response=True
+    )
+
+    # Assert success
+    assert response["success"] is True
+    assert "lines_exported" in response


### PR DESCRIPTION
The `export_diagnostic_logs` service was failing when called from the UI because it received a Device Registry ID, but the code expected a Config Entry ID. This fix adds logic to resolve the Device Registry ID to the corresponding Config Entry ID to find the correct coordinator.

Additionally, the service handler was assigning the response to `call.response`, which is not supported in recent Home Assistant versions for services defined with `supports_response=SupportsResponse.ONLY`. The handler has been updated to return the response dictionary directly.

A new test `tests/test_services.py` verifies the fix.

---
*PR created automatically by Jules for task [7106764965711786527](https://jules.google.com/task/7106764965711786527) started by @Xerolux*

## Summary by Sourcery

Resolve export_diagnostic_logs service failures when called with a device registry ID and update the service to return its response payload directly.

Bug Fixes:
- Allow export_diagnostic_logs to resolve coordinators when invoked with a device registry device_id instead of a config entry ID.
- Fix export_diagnostic_logs service response handling to return a response dictionary instead of assigning to call.response.

Tests:
- Add a regression test verifying export_diagnostic_logs succeeds when called with a device registry ID and returns a successful response.