### PR TITLE
Fix KeyError in async_setup_entry initialization

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -132,6 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryNotReady("Coordinator setup failed")
 
         # Store coordinator in hass.data
+        hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN][entry.entry_id] = coordinator
 
         # Load platforms

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,9 +74,6 @@ def coordinator() -> MagicMock:
 
 
 async def test_async_setup_entry_success(hass: HomeAssistant, config_entry: MockConfigEntry, coordinator: MagicMock) -> None:
-    # Ensure domain data exists (simulating async_setup)
-    hass.data.setdefault(DOMAIN, {})
-
     # Mock hass.config_entries.async_forward_entry_setups
     # In some HA versions/test setups this might be needed or it's an async method
     hass.config_entries.async_forward_entry_setups = AsyncMock()
@@ -117,9 +114,6 @@ async def test_async_setup_entry_missing_host(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    # Ensure domain data exists
-    hass.data.setdefault(DOMAIN, {})
-
     with patch.object(
         api_module,
         "VioletPoolAPI",
@@ -134,9 +128,6 @@ async def test_async_setup_entry_missing_host(hass: HomeAssistant) -> None:
 
 
 async def test_async_setup_entry_device_error(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
-    # Ensure domain data exists
-    hass.data.setdefault(DOMAIN, {})
-
     with patch.object(
         device_module,
         "async_setup_device",


### PR DESCRIPTION
This PR fixes a critical `KeyError: 'violet_pool_controller'` that occurred during the integration setup. The error happened because `hass.data[DOMAIN]` was accessed before being initialized.

Changes:
- Added `hass.data.setdefault(DOMAIN, {})` in `custom_components/violet_pool_controller/__init__.py` within `async_setup_entry` to ensure the domain dictionary exists.
- Removed manual `hass.data[DOMAIN]` initialization from `tests/test_integration.py` to ensure the fix is properly verified by tests and to prevent future regressions where tests might pass despite broken production code.

---
*PR created automatically by Jules for task [2198136572597166376](https://jules.google.com/task/2198136572597166376) started by @Xerolux*

## Summary by Sourcery

Prevent KeyError during violet_pool_controller config entry setup by ensuring the integration’s hass.data domain storage is initialized and relying on production initialization in tests.

Bug Fixes:
- Ensure hass.data[DOMAIN] is initialized in async_setup_entry before storing the coordinator to avoid KeyError on integration setup.

Tests:
- Remove manual hass.data[DOMAIN] initialization from integration tests so they exercise the real setup behavior and catch regressions.