### PR TITLE
Fix diagnostic log export path and add debug logging hint

### DIFF
--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -859,7 +859,7 @@ class VioletServiceHandlers:
             device_name = coordinator.device.device_name
 
             # Read from the main log file if available
-            log_path = "/config/home-assistant.log"
+            log_path = self.hass.config.path("home-assistant.log")
             if os.path.exists(log_path):
                 try:
                     with open(log_path, 'r', encoding='utf-8', errors='ignore') as f:
@@ -905,6 +905,17 @@ class VioletServiceHandlers:
                 log_entries.append("")
                 log_entries.append("No detailed log entries found in home-assistant.log.")
                 log_entries.append("Logs may have been rotated or not contain recent entries.")
+
+                # Check log level
+                try:
+                    logger = logging.getLogger("custom_components.violet_pool_controller")
+                    level = logger.getEffectiveLevel()
+                    if level > logging.DEBUG:
+                        log_entries.append("")
+                        log_entries.append("NOTE: Debug logging is currently disabled.")
+                        log_entries.append("To see more details, enable debug logging for this integration.")
+                except Exception:
+                    pass
 
             # Create export text
             export_header = f"""


### PR DESCRIPTION
This PR fixes an issue where the "Diagnostic Log Export" service would fail to find log entries on systems where the configuration directory is not mapped to `/config` or where the path resolution differs. It uses the standard `hass.config.path()` API to locate the log file. Additionally, it improves the user experience by providing a hint to enable debug logging if the export results are empty.

---
*PR created automatically by Jules for task [11305195935837905938](https://jules.google.com/task/11305195935837905938) started by @Xerolux*

## Summary by Sourcery

Fix diagnostic log export path resolution and improve feedback when no log entries are found.

Bug Fixes:
- Resolve diagnostic log export failures on systems where the configuration directory is not mounted at /config by using Home Assistant's config path API.

Enhancements:
- Add a diagnostic log export hint informing users when debug logging is disabled and suggesting enabling it for more detailed logs.