### PR TITLE
chore: Remove 2024 workflow validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         python-version: ["3.12"]
         home-assistant-version: 
-          - "2024.12.0"
           - "2025.1.0"
     
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ GitHub workflow `.github/workflows/validate.yml` runs:
 - Ruff linting
 - Mypy type checking
 - Full test suite with pytest
-- Tests against Home Assistant 2024.12.0 and 2025.1.0
+- Tests against Home Assistant 2025.1.0
 - Python 3.12 environment
 
 ## Translation Files


### PR DESCRIPTION
Removed Home Assistant 2024.12.0 from the validation matrix in .github/workflows/validate.yml. 
Also updated CLAUDE.md to reflect the change.
This is done to streamline the CI process and focus on newer versions (2025.1.0+).
Note: Version 2026 was not added as it is not yet available on PyPI.

---
*PR created automatically by Jules for task [16351288288353581006](https://jules.google.com/task/16351288288353581006) started by @Xerolux*

## Summary by Sourcery

Update CI validation matrix to drop Home Assistant 2024.12.0 support and align documentation with the current tested version.

CI:
- Remove Home Assistant 2024.12.0 from the validate workflow matrix, leaving only 2025.1.0.

Documentation:
- Adjust CLAUDE.md to document validation against Home Assistant 2025.1.0 only.