### PR TITLE
Fix diagnostic log export error by using correct HA version constant

### DIFF
--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -916,7 +916,16 @@ class VioletServiceHandlers:
                 log_entries.append("System Information:")
                 try:
                     # HA Version
-                    log_entries.append(f"  Home Assistant: {self.hass.config.version}")
+                    from homeassistant.const import __version__ as HA_VERSION
+                    log_entries.append(f"  Home Assistant: {HA_VERSION}")
+
+                    # HACS Version (if available)
+                    hacs = self.hass.data.get("hacs")
+                    if hacs:
+                        hacs_version = getattr(hacs, "version", None)
+                        if not hacs_version:
+                            hacs_version = getattr(hacs, "integration_version", "Unknown")
+                        log_entries.append(f"  HACS: {hacs_version}")
 
                     # Installation Type (if available)
                     if "hassio" in self.hass.config.components:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,12 +1,12 @@
 
 import pytest
 from unittest.mock import MagicMock
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, Config
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.violet_pool_controller.const import DOMAIN
-from custom_components.violet_pool_controller.services import async_register_services
+from custom_components.violet_pool_controller.services import async_register_services, VioletServiceHandlers, VioletServiceManager
 
 @pytest.mark.asyncio
 async def test_export_diagnostic_logs_failure(hass: HomeAssistant, device_registry: dr.DeviceRegistry):
@@ -62,3 +62,110 @@ async def test_export_diagnostic_logs_failure(hass: HomeAssistant, device_regist
     # Assert success
     assert response["success"] is True
     assert "lines_exported" in response
+
+
+# Mock Config class to simulate real behavior (no .version attribute)
+class RealConfig(Config):
+    def __init__(self):
+        self.components = {"http", "websocket_api"}
+        self.time_zone = "UTC"
+        # Explicitly do NOT set version
+
+    def path(self, *args):
+        return "/config/home-assistant.log"
+
+@pytest.mark.asyncio
+async def test_reproduce_config_version_error(hass):
+    # Setup hass with a restricted Config object
+    real_config = RealConfig()
+    hass.config = real_config
+
+    # Mock manager
+    manager = VioletServiceManager(hass)
+    handlers = VioletServiceHandlers(manager)
+
+    # Mock call data
+    call = MagicMock()
+    call.data = {"device_id": ["test_device"]}
+
+    # Mock manager.get_coordinator_for_device to return a coordinator
+    mock_coordinator = MagicMock()
+    mock_coordinator.device.device_name = "Test Device"
+    # ... set other attributes to avoid other errors
+    mock_coordinator.device.controller_name = "Violet"
+    mock_coordinator.device.api_url = "http://localhost"
+    mock_coordinator.device.device_id = "1"
+    mock_coordinator.device.available = True
+    mock_coordinator.device.firmware_version = "1.0"
+    mock_coordinator.device.last_event_age = 1
+    mock_coordinator.device.connection_latency = 10
+    mock_coordinator.device.system_health = 100
+    mock_coordinator.device._update_counter = 1
+    mock_coordinator.device.consecutive_failures = 0
+    mock_coordinator.config_entry = MagicMock()
+    mock_coordinator.config_entry.data = {}
+
+    # Make get_coordinator_for_device awaitable
+    async def get_coordinator(*args, **kwargs):
+        return mock_coordinator
+
+    manager.get_coordinator_for_device = MagicMock(side_effect=get_coordinator)
+
+    # Execute
+    result = await handlers.handle_export_diagnostic_logs(call)
+
+    # Check if error message is in logs
+    logs = result["logs"]
+    # Error should be gone
+    assert "Error retrieving system info" not in logs
+    # HA Version should be present
+    from homeassistant.const import __version__ as HA_VERSION
+    assert f"Home Assistant: {HA_VERSION}" in logs
+
+@pytest.mark.asyncio
+async def test_hacs_version_display(hass):
+    # Setup hass with a restricted Config object
+    real_config = RealConfig()
+    hass.config = real_config
+
+    # Mock HACS
+    mock_hacs = MagicMock()
+    mock_hacs.version = "1.2.3"
+    hass.data["hacs"] = mock_hacs
+
+    # Mock manager
+    manager = VioletServiceManager(hass)
+    handlers = VioletServiceHandlers(manager)
+
+    # Mock call data
+    call = MagicMock()
+    call.data = {"device_id": ["test_device"]}
+
+    # Mock manager.get_coordinator_for_device to return a coordinator
+    mock_coordinator = MagicMock()
+    mock_coordinator.device.device_name = "Test Device"
+    mock_coordinator.device.controller_name = "Violet"
+    mock_coordinator.device.api_url = "http://localhost"
+    mock_coordinator.device.device_id = "1"
+    mock_coordinator.device.available = True
+    mock_coordinator.device.firmware_version = "1.0"
+    mock_coordinator.device.last_event_age = 1
+    mock_coordinator.device.connection_latency = 10
+    mock_coordinator.device.system_health = 100
+    mock_coordinator.device._update_counter = 1
+    mock_coordinator.device.consecutive_failures = 0
+    mock_coordinator.config_entry = MagicMock()
+    mock_coordinator.config_entry.data = {}
+
+    # Make get_coordinator_for_device awaitable
+    async def get_coordinator(*args, **kwargs):
+        return mock_coordinator
+
+    manager.get_coordinator_for_device = MagicMock(side_effect=get_coordinator)
+
+    # Execute
+    result = await handlers.handle_export_diagnostic_logs(call)
+
+    # Check for HACS version
+    logs = result["logs"]
+    assert "HACS: 1.2.3" in logs


### PR DESCRIPTION
This PR fixes an `AttributeError: 'Config' object has no attribute 'version'` in the `export_diagnostic_logs` service.
The `hass.config.version` attribute has been removed or is not available in the context of `Config` object. The correct way to get Home Assistant version is via `homeassistant.const.__version__`.

Changes:
- Replaced `self.hass.config.version` with `homeassistant.const.__version__` in `custom_components/violet_pool_controller/services.py`.
- Added logic to safely retrieve and display HACS version if installed (`hass.data['hacs']`), addressing the user's request.
- Added regression tests in `tests/test_services.py` to ensure `export_diagnostic_logs` works correctly and handles version retrieval properly.

Testing:
- Verified with reproduction test case that `hass.config.version` access fails and the fix resolves it.
- Verified that HACS version is displayed if mocked.
- Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [8790640353239366641](https://jules.google.com/task/8790640353239366641) started by @Xerolux*