### PR TITLE
Potential fix for code scanning alert no. 7040: Unused local variable

### DIFF
--- a/custom_components/violet_pool_controller/services.py
+++ b/custom_components/violet_pool_controller/services.py
@@ -999,8 +999,6 @@ class VioletServiceHandlers:
                         if isinstance(features, list):
                             from .const_features import AVAILABLE_FEATURES
 
-                            # Create feature mapping
-                            feature_map = {f["id"]: f["name"] for f in AVAILABLE_FEATURES}
                             enabled_features = []
                             disabled_features = []
 


### PR DESCRIPTION
Potential fix for [https://github.com/Xerolux/violet-hass/security/code-scanning/7040](https://github.com/Xerolux/violet-hass/security/code-scanning/7040)

To fix the problem, remove the unused local variable assignment while preserving the rest of the logic. Since the right-hand side of the assignment (`{f["id"]: f["name"] for f in AVAILABLE_FEATURES}`) has no side effects (it just builds a dict from an in-memory list), it is safe to delete the entire line without replacing it.

Concretely, in `custom_components/violet_pool_controller/services.py`, inside the block that handles `CONF_ACTIVE_FEATURES` (lines ~997–1017), delete the line that defines `feature_map` (line 1003). No other code needs to be updated: `enabled_features` and `disabled_features` are already computed by iterating over `AVAILABLE_FEATURES`, independent of `feature_map`. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
