### PR TITLE
Fix config flow handler not found by adding domain=DOMAIN

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -63,7 +63,7 @@ from .config_flow_utils import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class ConfigFlow(config_entries.ConfigFlow):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config Flow für Violet Pool Controller."""
 
     VERSION = 1


### PR DESCRIPTION
The ConfigFlow class was missing the required `domain=DOMAIN` keyword argument, which prevented Home Assistant from registering the flow handler for the violet_pool_controller integration.

