### PR TITLE
docs: update wiki versions to 1.0.3-alpha.1

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -4,7 +4,31 @@
 
 ---
 
-## [1.0.2-beta.5] – 2026-02-25 🧪 BETA
+## [1.0.3-alpha.1] – 2026-02-28 🔴 ALPHA
+
+### Neue Features
+
+- **Quality Scale Progress:** Dokumentation des Fortschritts zur Quality Scale hinzugefügt (Gold Level ~85% abgeschlossen).
+
+### Verbesserungen
+
+- **Code Quality:** Type Hints vervollständigt (Bronze Level 100% abgeschlossen).
+- **Fehlerbehebung:** Behebung von Config Flow Handler Problemen.
+- **HA 2026 Kompatibilität:** Fixes für Home Assistant 2026 Kompatibilität und Abschluss von Gold Level Tests.
+- **ZeroConf Discovery:** Fixes für ZeroConf Discovery (100% Tests erfolgreich).
+
+### Dokumentation
+
+- **Enhanced Documentation:** Verbesserte Fehlerbehandlung, Diagnostics und Dokumentation (Silver Level 100% abgeschlossen).
+
+### Kompatibilität
+- Getestet auf Home Assistant 2025.12.0+
+- Vorbereitet für 2026.x Versionen
+- aiohttp>=3.10.0 erforderlich
+
+---
+
+## [1.0.2] – 2026-02-26 ✅ STABLE
 
 ### Neue Features
 
@@ -13,6 +37,7 @@
 - Exportiere bis zu 10.000 Log-Zeilen für Troubleshooting
 - Optional in Datei speichern für Support-Tickets
 - Mit Timestamps und flexibler Zeilenanzahl
+- Export enthält nun auch installierte Komponenten und Home Assistant System-Infos.
 
 ### Verbesserungen
 

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -37,7 +37,7 @@ Beiträge sind herzlich willkommen – egal ob Bug-Reports, Feature-Requests, Do
 
 2. ENVIRONMENT
    - Home Assistant Version: 2026.x.x (Minimum: 2025.12.0)
-   - Integration Version: 1.0.2-beta.5
+   - Integration Version: 1.0.3-alpha.1
    - Controller Firmware: x.x.x
    - Python Version: 3.12+
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -14,7 +14,7 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 | **Protokoll** | HTTP/HTTPS, lokales Polling |
 | **HA-Mindestversion** | 2025.12.0 |
 | **Python** | 3.12+ |
-| **Version** | 1.0.2-beta.5 |
+| **Version** | 1.0.3-alpha.1 |
 | **Lizenz** | MIT |
 | **Sprachen** | DE, EN, ES, FR, IT, NL, PL, PT, RU, ZH |
 
@@ -146,5 +146,5 @@ Home Assistant
 
 ---
 
-*Diese Wiki dokumentiert Version **1.0.2-beta.5** des Violet Pool Controller Addons.*
-*Zuletzt aktualisiert: 2026-02-25*
+*Diese Wiki dokumentiert Version **1.0.3-alpha.1** des Violet Pool Controller Addons.*
+*Zuletzt aktualisiert: 2026-02-28*

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -59,9 +59,9 @@ Hier findest du alles, was du brauchst - von der Installation bis zur Deinstalla
 
 ## 🔄 Auf dem neuesten Stand
 
-Diese Wiki dokumentiert **Version 1.0.2-beta.5** des Violet Pool Controller Home Assistant Addons.
+Diese Wiki dokumentiert **Version 1.0.3-alpha.1** des Violet Pool Controller Home Assistant Addons.
 
-Letzte Aktualisierung: **2026-02-25**
+Letzte Aktualisierung: **2026-02-28**
 
 ---
 

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,3 +1,3 @@
 ---
-**Violet Pool Controller** v1.0.2-beta.5 · [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/) · Lizenz: MIT · Requires HA 2025.12.0+ (getestet bis 2026.x)
+**Violet Pool Controller** v1.0.3-alpha.1 · [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/) · Lizenz: MIT · Requires HA 2025.12.0+ (getestet bis 2026.x)
 Developed with ❤️ for the Home Assistant & Pool Community · [Buy Me a Coffee](https://buymeacoffee.com/xerolux)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -34,7 +34,7 @@
 
 ---
 
-**Version:** 1.0.2-beta.5
+**Version:** 1.0.3-alpha.1
 **HA:** 2025.12.0+ (getestet bis 2026.x)
 
 [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/)


### PR DESCRIPTION
This change updates the GitHub wiki documentation by:
- Bumping all version occurrences in `docs/wiki/` from `1.0.2-beta.5` to `1.0.3-alpha.1`
- Updating the `docs/wiki/Changelog.md` to reflect the latest `1.0.3-alpha.1` release notes and `1.0.2` release notes.
- Updating the `Last updated` date on the `Home.md` and `README.md` wiki files to `2026-02-28`.

These files are synced automatically to the GitHub Wiki repository via the `wiki-sync.yml` workflow when pushed to the main branch.

---
*PR created automatically by Jules for task [1298266373723263170](https://jules.google.com/task/1298266373723263170) started by @Xerolux*