### PR TITLE
replace ZeroconfServiceInfo with AsyncServiceInfo for HA 2026 co…

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.components.zeroconf import AsyncServiceInfo
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, selector
@@ -413,7 +413,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         )
 
     async def async_step_zeroconf(
-        self, discovery_info: ZeroconfServiceInfo
+        self, discovery_info: AsyncServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery of a Violet Pool Controller.
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant import config_entries
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.components.zeroconf import AsyncServiceInfo
 from homeassistant.core import HomeAssistant
 
 
@@ -31,7 +31,7 @@ class TestVioletPoolControllerDiscovery:
     @pytest.fixture
     def mock_zeroconf_info(self):
         """Create a mock ZeroConf service info."""
-        info = MagicMock(spec=ZeroconfServiceInfo)
+        info = MagicMock(spec=AsyncServiceInfo)
         info.name = "Violet Pool Controller._http._tcp.local."
         info.host = "192.168.178.55"
         info.port = 80
@@ -186,7 +186,7 @@ class TestZeroConfIntegration:
     @pytest.fixture
     def mock_zeroconf_info(self):
         """Create a mock ZeroConf service info."""
-        info = MagicMock(spec=ZeroconfServiceInfo)
+        info = MagicMock(spec=AsyncServiceInfo)
         info.name = "Violet Pool Controller._http._tcp.local."
         info.host = "192.168.178.55"
         info.port = 80
@@ -270,7 +270,7 @@ class TestDiscoveryErrorHandling:
         handler = VioletPoolControllerDiscovery()
 
         # Create invalid service info with None values
-        invalid_info = MagicMock(spec=ZeroconfServiceInfo)
+        invalid_info = MagicMock(spec=AsyncServiceInfo)
         invalid_info.name = "Invalid Device"
         invalid_info.host = None
         invalid_info.port = None
@@ -333,14 +333,14 @@ class TestDiscoveryMultipleDevices:
         mock_hass = MagicMock(spec=HomeAssistant)
 
         # Create multiple device infos
-        device1 = MagicMock(spec=ZeroconfServiceInfo)
+        device1 = MagicMock(spec=AsyncServiceInfo)
         device1.name = "Violet Pool Controller 1._http._tcp.local."
         device1.host = "192.168.178.55"
         device1.port = 80
         device1.hostname = "violet-1"
         device1.type = "_http._tcp.local."
 
-        device2 = MagicMock(spec=ZeroconfServiceInfo)
+        device2 = MagicMock(spec=AsyncServiceInfo)
         device2.name = "Violet Pool Controller 2._http._tcp.local."
         device2.host = "192.168.178.56"
         device2.port = 80
@@ -378,7 +378,7 @@ class TestDiscoveryMultipleDevices:
         mock_hass = MagicMock(spec=HomeAssistant)
 
         # Create device info
-        device = MagicMock(spec=ZeroconfServiceInfo)
+        device = MagicMock(spec=AsyncServiceInfo)
         device.name = "Violet Pool Controller._http._tcp.local."
         device.host = "192.168.178.55"
         device.port = 80


### PR DESCRIPTION
…mpatibility

ZeroconfServiceInfo was removed from homeassistant.components.zeroconf in Home Assistant 2026, causing an ImportError that prevented the integration from loading. Replace with AsyncServiceInfo in config_flow.py and test_discovery.py to match the updated HA API.

## Summary by Sourcery

Update Zeroconf discovery handling to use the new AsyncServiceInfo API required by newer Home Assistant versions.

Bug Fixes:
- Fix integration import error by replacing deprecated ZeroconfServiceInfo with AsyncServiceInfo in config flow and related tests.

Tests:
- Update Zeroconf discovery tests to mock AsyncServiceInfo instead of the removed ZeroconfServiceInfo class.