### PR TITLE
move repairs imports to homeassistant.helpers.issue_registry for…

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
-from homeassistant.components.repairs import IssueSeverity, async_create_issue, async_delete_issue
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady


### PR DESCRIPTION
… HA 2026

I

## Summary by Sourcery

Align repairs-related imports in the Violet Pool Controller integration with the updated Home Assistant 2026 helpers API.