### PR TITLE
slim README, expand wiki with diagnostics page and HA 2026 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,572 +11,87 @@
 [![Buy Me A Coffee][buymeacoffee-badge]][buymeacoffee]
 [![Tesla](https://img.shields.io/badge/Tesla-Referral-red?style=for-the-badge&logo=tesla)](https://ts.la/sebastian564489)
 
-
 [![Release Management](https://github.com/Xerolux/violet-hass/actions/workflows/release.yml/badge.svg)](https://github.com/Xerolux/violet-hass/actions/workflows/release.yml)
 
-
-> **Verwandle deinen Pool in einen Smart Pool!** Diese umfassende Home Assistant Integration bietet vollständige Kontrolle und Überwachung deines Violet Pool Controllers.
+> **Verwandle deinen Pool in einen Smart Pool!** Vollständige lokale Steuerung und Überwachung deines Violet Pool Controllers – ohne Cloud, ohne Abonnement.
 
 ![Violet Home Assistant Integration][logo]
-
-## 📋 Inhaltsverzeichnis
-
-- [🌟 Features](#-features)
-- [⚡ Schnellstart](#-schnellstart) 
-- [📦 Installation](#-installation)
-- [⚙️ Konfiguration](#️-konfiguration)
-- [🧩 Verfügbare Entitäten](#-verfügbare-entitäten)
-- [🤖 Automatisierungen](#-automatisierungen)
-- [🚨 Fehlerbehebung](#-fehlerbehebung)
-- [💝 Unterstützung](#-unterstützung)
 
 ---
 
 ## 🌟 Features
 
-### 🎯 **Kernfunktionen**
-- **🌡️ Intelligente Klimasteuerung** - Heizung & Solar mit Zeitplanung
-- **🧪 Automatische Chemie-Dosierung** - pH & Chlor mit Sicherheitsgrenzen  
-- **🏊 Smarte Abdeckungssteuerung** - Wetterabhängige Automatisierung
-- **💧 Filter-Management** - Automatische Rückspülung & Wartung
-- **💡 LED-Beleuchtung** - Vollständige RGB/DMX-Steuerung
-- **📱 Mobile-Ready** - Kontrolle von überall über HA App
-- **🔧 100% Lokal** - Keine Cloud erforderlich, vollständige Privatsphäre
-
-### 📊 **Überwachung & Sensoren**
-- **Wasserchemie**: pH, Redox (ORP), Chlorgehalt mit Trend-Tracking
-- **Temperaturen**: Pool, Umgebung, Solar-Kollektor
-- **System-Status**: Pumpen, Heizung, Filterdruck, Wasserstände  
-- **Anlagen-Gesundheit**: Laufzeit, Fehlererkennung, Wartungsalarme
-
-### 🤖 **Smart Automation**
-- **Energie-Optimierung**: PV-Überschuss-Modus für Solarheizung
-- **Wetter-Integration**: Automatische Reaktionen auf Umweltbedingungen
-- **Wartungsplanung**: Intelligente Zyklen für alle Anlagenteile
-- **Sicherheitssysteme**: Notabschaltungen & Überlaufschutz
-- **Custom Scenes**: Pool-Party, Eco, Winter & Urlaubs-Modi
+| Kategorie | Was ist enthalten |
+|-----------|-------------------|
+| **🌡️ Klimasteuerung** | Heizung & Solar mit Thermostat und Zeitplanung |
+| **🧪 Chemie-Dosierung** | Automatisches pH & Chlor mit Sicherheitsgrenzen |
+| **💧 Filter & Pumpe** | 3-Stufen-Pumpe, automatische Rückspülung |
+| **🏊 Abdeckung** | Wetterabhängige Cover-Automatisierung |
+| **💡 LED / DMX** | 8 steuerbare Szenen, RGB-Beleuchtung |
+| **📊 Überwachung** | pH, ORP, Temperaturen, Druck, Durchfluss, Laufzeiten |
+| **⚡ Energie** | PV-Überschuss-Modus für Solarheizung |
+| **🔒 Sicherheit** | 100% lokal, SSL/TLS, Rate Limiting, Input Sanitization |
+| **🔧 Multi-Controller** | Mehrere Pools in einer HA-Instanz |
 
 ---
 
 ## ⚡ Schnellstart
 
-### 1. Vorbereitung
-- ✅ Home Assistant 2024.6+ installiert (getestet mit 2024.12.0 und 2025.1.4)
-- ✅ HACS installiert ([Anleitung](https://hacs.xyz/docs/setup/download))
-- ✅ Violet Pool Controller im Netzwerk erreichbar
-- ✅ Controller-IP-Adresse bekannt (z.B. 192.168.1.100)
-
-### 2. Installation (2 Minuten)
+**1. HACS – Integration hinzufügen**
 ```
-HACS → Integrationen → Custom Repository hinzufügen:
-Repository: https://github.com/xerolux/violet-hass
-Kategorie: Integration
+HACS → Integrationen → ⋮ → Benutzerdefinierte Repositories
+URL: https://github.com/xerolux/violet-hass  |  Kategorie: Integration
+→ "Violet Pool Controller" herunterladen → HA neu starten
 ```
 
-### 3. Konfiguration (3 Minuten)
+**2. Integration einrichten**
 ```
 Einstellungen → Geräte & Dienste → Integration hinzufügen → "Violet Pool Controller"
-Host eingeben → Features auswählen → Fertig!
+Host-IP eingeben → Features auswählen → Fertig!
 ```
 
-**🎉 Geschafft!** Dein Pool ist jetzt smart und bereit für Automatisierungen.
+**3. Fertig!** 🎉 Dein Pool ist jetzt smart.
+
+> Detaillierte Anleitung → **[Installation & Setup][wiki-install]**
 
 ---
 
-## 📦 Installation
+## 📖 Dokumentation (Wiki)
 
-### 🚀 **HACS Installation (Empfohlen)**
+Die vollständige Dokumentation befindet sich im **[Wiki][wiki]**:
 
-**Schritt 1: Repository hinzufügen**
-1. HACS öffnen → ⋮ (drei Punkte) → "Benutzerdefinierte Repositorys"
-2. URL: `https://github.com/xerolux/violet-hass`
-3. Kategorie: "Integration" → "Hinzufügen"
-
-**Schritt 2: Integration installieren**
-1. Nach "Violet Pool Controller" suchen
-2. "Herunterladen" klicken
-3. Home Assistant neu starten
-
-### 🔧 **Manuelle Installation**
-
-<details>
-<summary>Für Entwickler & Fortgeschrittene (Klicken zum Erweitern)</summary>
-
-```bash
-# Option 1: Git Clone
-cd /config/custom_components/
-git clone https://github.com/xerolux/violet-hass.git violet_pool_controller
-
-# Option 2: Download
-wget https://github.com/xerolux/violet-hass/archive/main.zip
-unzip main.zip
-mv violet-hass-main/custom_components/violet_pool_controller /config/custom_components/
-
-# Neustart erforderlich
-```
-</details>
+| Bereich | Seiten |
+|---------|--------|
+| 🚀 **Erste Schritte** | [Installation & Setup][wiki-install] · [Konfiguration][wiki-config] · [Multi-Controller][wiki-multi] |
+| 📊 **Entities** | [Sensoren][wiki-sensors] · [Schalter][wiki-switches] · [Klima][wiki-climate] · [Device States][wiki-states] |
+| ⚙️ **Automatisierung** | [Services Referenz][wiki-services] · [Automatisierungs-Beispiele][wiki-automations] |
+| 🔧 **Betrieb** | [Troubleshooting][wiki-trouble] · [Diagnosedaten][wiki-diag] · [Fehler-Codes][wiki-errors] · [FAQ][wiki-faq] |
+| 🔐 **Sicherheit** | [Security & SSL][wiki-security] · [Erweiterte Protokollierung][wiki-logging] |
+| 👩‍💻 **Entwicklung** | [Contributing][wiki-contributing] · [API Referenz][wiki-api] · [Changelog][wiki-changelog] |
 
 ---
 
-## ⚙️ Konfiguration
-
-### 🎯 **Basis-Setup**
-
-Die Konfiguration erfolgt komplett über die UI – kein YAML nötig!
-
-**Integration hinzufügen:**
-```
-Einstellungen → Geräte & Dienste → Integration hinzufügen → "Violet Pool Controller"
-```
-
-### 📋 **Konfigurationsoptionen**
-
-| Einstellung | Beispiel | Beschreibung |
-|-------------|----------|--------------|
-| **Host** | `192.168.1.100` | IP-Adresse des Controllers |
-| **Username/Password** | `admin` / `••••` | Optional für Basic Auth |
-| **SSL verwenden** | ☑ | Bei HTTPS-Nutzung aktivieren |
-| **Abfrageintervall** | `30s` | Update-Frequenz (10–300 s) |
-| **Pool-Größe** | `50 m³` | Für Dosierungsberechnungen |
-| **Pool-Typ & Desinfektion** | `outdoor`, `chlorine` | Optimiert Default-Werte |
-
-### 🎛️ **Feature- & Sensor-Auswahl**
-
-Der Einrichtungsassistent führt dich durch zwei Auswahllisten:
-
-1. **Aktive Features** – nur Komponenten aktivieren, die auch verkabelt sind (z. B. Heizung, Solar, PV-Überschuss, digitale Eingänge).
-2. **Dynamische Sensoren** – beim ersten Start werden alle Sensoren des Controllers gelesen und gruppiert. Du kannst per Mehrfachauswahl entscheiden, welche Werte in Home Assistant landen sollen.
-
-> 💡 Keine Auswahl getroffen? Dann erstellt die Integration automatisch alle verfügbaren Sensoren (voll kompatibel zu bestehenden Installationen).
-
-### 🧰 Erweiterte Optionen
-
-Über *Einstellungen → Geräte & Dienste → Violet Pool Controller → Konfigurieren* kannst du jederzeit nachjustieren:
-
-- Abfrageintervall, Timeout und Retry-Limits
-- Aktive Features (z. B. PV-Überschuss nur im Sommer)
-- Sensor-Gruppen (praktisch, wenn du die Anzeige auf die wichtigsten Werte reduzieren willst)
-
-Alle Änderungen werden ohne Neustart übernommen.
-
----
-
-## 🖥️ Lovelace Dashboard
-
-Damit du sofort loslegen kannst, liegt ein fertiges Dashboard bei:
-
-- YAML-Datei: [`Dashboard/pool-dashboard.yaml`](Dashboard/pool-dashboard.yaml)
-- Vorschau-Bild: ![Pool Dashboard Vorschau](screenshots/pool-dashboard.svg)
-
-**Installation:**
-
-1. Datei `Dashboard/pool-dashboard.yaml` nach `/config/` kopieren.
-2. Optional: `screenshots/pool-dashboard.svg` nach `/config/www/violet-hass/` legen, damit das Dashboard das Vorschaubild findet.
-3. In Home Assistant → *Einstellungen → Dashboards* → ⋮ → *Dashboard aus YAML importieren*.
-4. Falls deine Entitäten anders heißen (z. B. wegen mehrerer Controller), per Suchen/Ersetzen in der YAML-Datei anpassen.
-
-Das Dashboard nutzt ausschließlich Standard-Karten – keine zusätzlichen Custom-Cards nötig.
-
----
-
-## 🧩 Verfügbare Entitäten
-
-Die Integration erstellt automatisch alle relevanten Entitäten basierend auf deiner Controller-Konfiguration:
-
-### 🌡️ **Klimasteuerung**
-```yaml
-climate.pool_heater          # Hauptheizung mit Thermostat
-climate.pool_solar           # Solar-Kollektor Management
-```
-
-### 📊 **Sensoren** 
-```yaml
-# Wasserchemie
-sensor.pool_temperature      # Aktuelle Wassertemperatur  
-sensor.pool_ph_value         # pH-Wert (6.0-8.5)
-sensor.pool_orp_value        # Redoxpotential (mV)
-sensor.pool_chlorine_level   # Freies Chlor (mg/l)
-
-# System-Status
-sensor.filter_pressure       # Filtersystem-Druck
-sensor.water_level          # Pool-Wasserstand
-sensor.pump_runtime         # Pumpen-Laufzeit heute
-sensor.energy_consumption   # Energieverbrauch
-```
-
-### 💡 **Schalter & Steuerungen**
-```yaml
-# Hauptkomponenten
-switch.pool_pump            # Filterpumpe (variable Geschwindigkeit)
-switch.pool_heater          # Heizung Ein/Aus
-switch.pool_solar           # Solar-Zirkulation
-switch.pool_lighting        # Pool-Beleuchtung
-
-# Chemie-Dosierung  
-switch.ph_dosing_minus      # pH- Dosierpumpe
-switch.ph_dosing_plus       # pH+ Dosierpumpe
-switch.chlorine_dosing      # Chlor-Dosierung
-
-# Wartung & Extras
-switch.backwash             # Rückspül-Zyklus
-switch.pool_cover           # Abdeckung
-switch.pv_surplus_mode      # Solar-Überschuss-Modus
-```
-
----
-
-## 🤖 Automatisierungen
-
-### 🎯 **Custom Services**
-
-Die Integration bietet spezialisierte Services für erweiterte Automatisierung:
-
-<details>
-<summary><strong>🔧 Kern-Services</strong> (Klicken zum Erweitern)</summary>
-
-#### `violet_pool_controller.control_pump`
-Pumpe in Automatikmodus schalten:
-```yaml
-service: violet_pool_controller.control_pump
-target:
-  entity_id: switch.pool_pump
-data:
-  action: auto
-```
-
-#### `violet_pool_controller.manage_pv_surplus`
-Solar-Überschuss-Modus aktivieren:
-```yaml
-service: violet_pool_controller.manage_pv_surplus
-target:
-  entity_id: switch.pv_surplus_mode
-data:
-  mode: activate
-  pump_speed: 2   # Geschwindigkeitsstufe 1-3
-```
-</details>
-
-<details>
-<summary><strong>🧪 Chemie-Services</strong> (Klicken zum Erweitern)</summary>
-
-#### `violet_pool_controller.smart_dosing`
-Manuelle Dosierung auslösen:
-```yaml
-service: violet_pool_controller.smart_dosing
-target:
-  entity_id: switch.ph_dosing_minus
-data:
-  dosing_type: "pH-"
-  action: manual_dose
-  duration: 30  # Dosierdauer in Sekunden
-```
-</details>
-
-### 📋 **Beispiel-Automatisierungen**
-
-#### 🌡️ **Intelligente Poolheizung mit Solar-Unterstützung**
-
-```yaml
-# Heize Pool wenn Solarkollektor > 35°C und Pool < 28°C
-- alias: "Pool: Solarheizung bei Sonne"
-  trigger:
-    - platform: numeric_state
-      entity_id: sensor.solar_temp
-      above: 35
-  condition:
-    - condition: numeric_state
-      entity_id: sensor.pool_temperature
-      below: 28
-    - condition: state
-      entity_id: switch.pool_pump
-      state: "on"
-  action:
-    - service: climate.turn_on
-      target:
-        entity_id: climate.pool_heater
-    - service: climate.set_temperature
-      target:
-        entity_id: climate.pool_heater
-      data:
-        temperature: 28
-```
-
-#### 🧪 **Automatische pH-Korrektur**
-
-```yaml
-# pH-Plus dosieren wenn pH < 7.0
-- alias: "Pool: pH zu niedrig - dosiere pH+"
-  trigger:
-    - platform: numeric_state
-      entity_id: sensor.pool_ph_value
-      below: 7.0
-      for:
-        minutes: 5
-  condition:
-    - condition: state
-      entity_id: switch.pool_pump
-      state: "on"
-  action:
-    - service: switch.turn_on
-      target:
-        entity_id: switch.ph_dosing_plus
-    - wait_template: "{{ states('sensor.pool_ph_value') | float > 7.2 }}"
-      timeout:
-        minutes: 30
-    - service: switch.turn_off
-      target:
-        entity_id: switch.ph_dosing_plus
-```
-
-#### ⚡ **Energie-Optimierung mit PV-Überschuss**
-
-```yaml
-# Aktiviere PV-Überschuss-Modus bei hohem Solarertrag
-- alias: "Pool: PV-Überschuss nutzen"
-  trigger:
-    - platform: numeric_state
-      entity_id: sensor.pv_power_export
-      above: 2000  # Watt
-  action:
-    - service: violet_pool_controller.manage_pv_surplus
-      target:
-        entity_id: switch.pv_surplus_mode
-      data:
-        mode: activate
-        pump_speed: 2
-```
-
-#### 🌧️ **Abdeckung schließen bei Regen**
-
-```yaml
-- alias: "Pool: Abdeckung bei Regen schließen"
-  trigger:
-    - platform: state
-      entity_id: weather.pools_weather
-      to: "rainy"
-  action:
-    - service: cover.close_cover
-      target:
-        entity_id: cover.pool_cover
-```
-
-### 📋 **Automation Blueprints**
-
-**Installation:**
-```
-Einstellungen → Automatisierungen & Szenen → Blueprints → Blueprint importieren
-```
-
-**Verfügbare Blueprints:**
-- 🌡️ **Intelligente Temperatursteuerung** - Tag/Nacht-Modi mit Solar-Priorität
-- 🧪 **pH-Management** - Automatische Dosierung mit Sicherheitsgrenzen
-- ⚡ **Energie-Optimierung** - PV-Überschuss-Nutzung
-- 🌧️ **Wetter-Reaktionen** - Abdeckung bei Regen/Wind
-- 🏊 **Pool-Modi** - Party, Eco, Winter & Urlaubs-Automatisierungen
-
----
-
-## 🚨 Fehlerbehebung
-
-### ⚡ **Häufige Probleme & Lösungen**
-
-| Problem | Schnelle Lösung |
-|---------|-----------------|
-| **Keine Verbindung** | IP-Adresse & Firewall prüfen |
-| **SSL-Fehler** | "SSL verwenden" Setting anpassen |
-| **Entitäten fehlen** | Controller-Features & Integration neu laden |
-| **Langsame Updates** | Abfrageintervall verringern (min. 10s) |
-
-### 🔍 **Detaillierte Lösungen**
-
-#### ❌ **"Failed to connect" - Keine Verbindung möglich**
-
-**Symptome:**
-- Integration zeigt "Nicht verfügbar"
-- Log-Meldung: "Connection refused" oder "Timeout"
-
-**Lösungsschritte:**
-1. **Konnektivität prüfen:**
-   ```bash
-   ping 192.168.1.100
-   curl http://192.168.1.100/getReadings?ALL
-   ```
-2. **Firewall prüfen:**
-   - Stelle sicher, dass Port 80 (HTTP) oder 443 (HTTPS) nicht blockiert ist
-   - Home Assistant Host muss Zugriff auf Controller-Subnetz haben
-3. **Controller-Status prüfen:**
-   - Controller-WebUI erreichbar? (http://192.168.1.100)
-   - Licht am Controller leuchtet?
-
-#### 🔐 **SSL_Zertifiziert-Fehler**
-
-**Symptome:**
-- Log-Meldung: "SSL: CERTIFICATE_VERIFY_FAILED"
-- Integration kann bei "SSL verwenden" nicht aktiviert werden
-
-**Lösung:**
-- Option 1: **"SSL verwenden" deaktivieren** (für selbstsignierte Zertifikate)
-- Option 2: **"Zertifikat verifizieren" deaktivieren** im Config-Flow
-- Option 3: Eigene CA-Zertifikate in HA importieren (Fortgeschritten)
-
-#### 📊 **Sensoren zeigen "Unbekannt" oder falsche Werte**
-
-**Mögliche Ursachen:**
-1. **Feature nicht aktiviert:**
-   - Gehe zu: *Einstellungen → Geräte & Dienste → Violet Pool Controller → Konfigurieren*
-   - Prüfe unter "Aktive Features" ob das korrekte Feature aktiviert ist
-   - Speichern und Integration neu laden
-
-2. **Falsche Sensor-Auswahl:**
-   - Beim Setup wurde die Gruppe des Sensors abgewählt
-   - Lösung: Neu konfigurieren und alle relevanten Sensor-Gruppen auswählen
-
-3. **Controller-Fehler:**
-   - Prüfe Controller-Logs: http://192.168.1.100/logs
-   - Restart des Controllers: Strom für 30 Sekunden entfernen
-
-#### ⏱️ **Entitäten aktualisieren nicht (stale values)**
-
-**Ursache:** Abfrageintervall zu hoch oder Controller antwortet nicht
-
-**Lösung:**
-1. **Abfrageintervall reduzieren:**
-   - Gehe zu: *Einstellungen → Geräte & Dienste → Violet Pool Controller → Konfigurieren*
-   - "Abfrageintervall" auf 15-30 Sekunden setzen
-   - Speichern
-
-2. **Timeout anpassen:**
-   - "Timeout" auf 10-15 Sekunden erhöhen
-   - Besonders bei langsamen Netzwerken
-
-3. **Manueller Refresh:**
-   ```
-   Einstellungen → Geräte & Dienste → Violet Pool Controller → ⋮ → Neu laden
-   ```
-
-#### 🐛 **Integration startet nicht (Setup: Failed)**
-
-**Debug-Schritte:**
-
-1. **Logs prüfen:**
-   ```bash
-   tail -100 /config/home-assistant.log | grep violet
-   ```
-
-2. **Config Exportieren:**
-   ```
-   Einstellungen → Geräte & Dienste → Violet Pool Controller → ⋮ → Diagnosedaten exportieren
-   ```
-
-3. **Vollständiger Neustart:**
-   - Integration entfernen
-   - HA neu starten
-   - Integration neu einrichten
-
-### 🔍 **Werkzeuge zur Fehlersuche**
-
-#### **Diagnostic Export Service**
-
-Nutze den integrierten Diagnostic-Service:
-
-```yaml
-service: violet_pool_controller.export_diagnostic_logs
-data:
-  device_id:
-    - "deine_controller_id"
-  save_to_file: true
-```
-
-Dieser erstellt eine detaillierte Log-Datei mit:
-- ✅ Konfiguration
-- ✅ Alle Sensorwerte
-- ✅ Aktive Fehler
-- ✅ Laufzeiten
-- ✅ Historie der letzten 24h
-
-#### **Weitere Diagnose-Services**
-
-Die Integration bietet zusätzliche Services zur gezielten Fehleranalyse:
-
-- `violet_pool_controller.get_connection_status`: Detaillierte Verbindungsmetriken und Gesundheitsstatus.
-- `violet_pool_controller.get_error_summary`: Zusammenfassung aktueller Fehler mit Lösungsvorschlägen.
-- `violet_pool_controller.test_connection`: Direkter Verbindungstest zum Controller mit Latenzmessung.
-- `violet_pool_controller.clear_error_history`: Löscht die Fehlerhistorie nach erfolgreicher Behebung.
-
-#### **Live API-Test**
-
-Teste die API-Verbindung direkt:
-
-```bash
-# Alle Readings abrufen
-curl http://192.168.1.100/getReadings?ALL | jq
-
-# Konfiguration prüfen
-curl http://192.168.1.100/getConfig?TARGET_PH,TARGET_ORP
-
-# Manuelles Schalten testen
-curl "http://192.168.1.100/setFunctionManually?PUMP=ON"
-```
-
-#### **Log-Level erhöhen**
-
-Für detaillierte Logs:
-
-```yaml
-# configuration.yaml
-logger:
-  logs:
-    custom_components.violet_pool_controller: debug
-```
-
-**Wichtige Log-Meldungen:**
-- `ERROR` - Kritische Fehler die die Funktion beeinträchtigen
-- `WARNING` - Probleme die automatisch behoben wurden
-- `DEBUG` - Detaillierte Information für Fehlersuche
-- `INFO` - Normale Operations-Meldungen
-
-### 📞 **Support erhalten**
-
-Wenn du keine Lösung findest:
-
-1. **GitHub Issues** - [Bug melden][issues]
-   - Wähle passendes Template aus
-   - Logs anhängen (`!secret` entfernen!)
-   - HA-Version und Integrations-Version angeben
-
-2. **Community** - [Discord][discord] | [Forum][forum]
-   - Andere Nutzer haben vielleicht ähnliche Probleme gehabt
-   - Suche nach Fehlercodes und Fehlermeldungen
-
-3. **Direkt Kontakt** - [git@xerolux.de](mailto:git@xerolux.de)
-   - Für geschäftliche Anfragen
-   - Support-Priorität für Sponsoren
-
-### 📚 **Bekannte Probleme & Workarounds**
-
-| Issue | Status | Workaround |
-|-------|--------|-----------|
-| **Cover öffnet nicht vollständig** | Bekannt | Manuell in App korrigieren, dann Neu laden |
-| **pH-Wert springt** | Controller-Bug | Sensor kalibrieren (Controller-WebUI) |
-| **Heizung schaltet nicht ein** | Feature-Abhängig | Prüfe ob "heating" Feature aktiviert |
-| **PV-Überschuss nicht verfügbar** | Hardware-Abhängig | Requires compatible PV inverter |
+## 🔑 Voraussetzungen
+
+- Home Assistant **2025.12.0+** (getestet bis 2026.x)
+- HACS ([Installationsanleitung](https://hacs.xyz/docs/setup/download))
+- Violet Pool Controller im lokalen Netzwerk erreichbar
+- Python 3.12+
 
 ---
 
 ## 💝 Unterstützung
 
-Diese Integration wird in meiner Freizeit entwickelt. Wenn sie dir hilft, zeige etwas Liebe:
+Diese Integration wird in meiner Freizeit entwickelt:
 
 [![GitHub Sponsor](https://img.shields.io/github/sponsors/xerolux?logo=github&style=for-the-badge&color=blue)](https://github.com/sponsors/xerolux)
 [![Ko-Fi](https://img.shields.io/badge/Ko--fi-xerolux-blue?logo=ko-fi&style=for-the-badge)](https://ko-fi.com/xerolux)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-xerolux-yellow?logo=buy-me-a-coffee&style=for-the-badge)](https://www.buymeacoffee.com/xerolux)
 
-**Andere Unterstützungsmöglichkeiten:**
 - ⭐ Repository auf GitHub sternen
-- 📢 Mit anderen Pool-Besitzern teilen  
-- 🐛 Bugs melden & Verbesserungen vorschlagen
-- 📝 Code oder Dokumentation beitragen
-- 💬 Anderen in Community-Foren helfen
+- 🐛 [Bugs melden][issues]
+- 📢 Mit anderen Pool-Besitzern teilen
+- 💬 Anderen in [Community][forum] & [Discord][discord] helfen
 
 ---
 
@@ -584,26 +99,10 @@ Diese Integration wird in meiner Freizeit entwickelt. Wenn sie dir hilft, zeige 
 
 ![Violet Pool Controller][pbuy]
 
-Der **VIOLET Pool Controller** von [PoolDigital GmbH & Co. KG](https://www.pooldigital.de/) ist ein Premium Smart Pool Automation System aus deutscher Entwicklung.
+Der **VIOLET Pool Controller** von [PoolDigital GmbH & Co. KG](https://www.pooldigital.de/) ist ein Premium Smart Pool Automation System aus deutscher Entwicklung – mit JSON API für nahtlose Home Assistant Integration.
 
-**Warum Violet?**
-- 🔧 **Komplette Pool-Verwaltung** - Alles aus einer Hand
-- 📱 **Smart Home Ready** - JSON API für nahtlose Integration  
-- 🛡️ **Sicherheit First** - Mehrfache Schutz- & Überwachungssysteme
-- ⚡ **Energieeffizient** - Intelligente Planung & PV-Integration
-- 🇩🇪 **Made in Germany** - Premium Qualität & Support
-
-**Bezugsquellen:**
 - **Offizieller Shop:** [pooldigital.de](https://www.pooldigital.de/poolsteuerungen/violet-poolsteuerung/74/violet-basis-modul-poolsteuerung-smart)
 - **Community:** [PoolDigital Forum](http://forum.pooldigital.de/)
-
----
-
-## 🤝 Mitwirken
-
-Beiträge sind herzlich willkommen! Ob Bug-Fixes, neue Features, Dokumentation oder Tests:
-
----
 
 ---
 
@@ -611,15 +110,34 @@ Beiträge sind herzlich willkommen! Ob Bug-Fixes, neue Features, Dokumentation o
 
 **Made with ❤️ for the Home Assistant & Pool Community**
 
-*Transform your pool into a smart pool - because life's too short for manual pool maintenance!* 🏊‍♀️🤖
-
-[![GitHub][github-shield]][github] [![Discord][discord-shield]][discord] [![Email](https://img.shields.io/badge/email-git%40xerolux.de-blue?style=for-the-badge&logo=gmail)](mailto:git@xerolux.de) [![Tesla](https://img.shields.io/badge/Tesla-Referral-red?style=for-the-badge&logo=tesla)](https://ts.la/sebastian564489)
+[![GitHub][github-shield]][github] [![Discord][discord-shield]][discord] [![Email](https://img.shields.io/badge/email-git%40xerolux.de-blue?style=for-the-badge&logo=gmail)](mailto:git@xerolux.de)
 
 </div>
 
 ---
 
-<!-- Links -->
+<!-- Wiki Links -->
+[wiki]: https://github.com/Xerolux/violet-hass/wiki
+[wiki-install]: https://github.com/Xerolux/violet-hass/wiki/Installation-and-Setup
+[wiki-config]: https://github.com/Xerolux/violet-hass/wiki/Configuration
+[wiki-multi]: https://github.com/Xerolux/violet-hass/wiki/Multi-Controller
+[wiki-sensors]: https://github.com/Xerolux/violet-hass/wiki/Sensors
+[wiki-switches]: https://github.com/Xerolux/violet-hass/wiki/Switches
+[wiki-climate]: https://github.com/Xerolux/violet-hass/wiki/Climate
+[wiki-states]: https://github.com/Xerolux/violet-hass/wiki/Device-States
+[wiki-services]: https://github.com/Xerolux/violet-hass/wiki/Services
+[wiki-automations]: https://github.com/Xerolux/violet-hass/wiki/Automations
+[wiki-trouble]: https://github.com/Xerolux/violet-hass/wiki/Troubleshooting
+[wiki-diag]: https://github.com/Xerolux/violet-hass/wiki/Diagnostics
+[wiki-errors]: https://github.com/Xerolux/violet-hass/wiki/Error-Codes
+[wiki-faq]: https://github.com/Xerolux/violet-hass/wiki/FAQ
+[wiki-security]: https://github.com/Xerolux/violet-hass/wiki/Security
+[wiki-logging]: https://github.com/Xerolux/violet-hass/wiki/Erweiterte-Protokollierung
+[wiki-contributing]: https://github.com/Xerolux/violet-hass/wiki/Contributing
+[wiki-api]: https://github.com/Xerolux/violet-hass/wiki/API-Reference
+[wiki-changelog]: https://github.com/Xerolux/violet-hass/wiki/Changelog
+
+<!-- Badge Links -->
 [releases-shield]: https://img.shields.io/github/release/xerolux/violet-hass.svg?style=for-the-badge
 [releases]: https://github.com/xerolux/violet-hass/releases
 [downloads-shield]: https://img.shields.io/github/downloads/xerolux/violet-hass/latest/total.svg?style=for-the-badge

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -4,6 +4,25 @@
 
 ---
 
+## [1.0.3-alpha.2] – 2026-03-02 🔴 ALPHA
+
+### Bugfixes (HA 2026 Kompatibilität)
+
+- **ZeroconfServiceInfo entfernt**: `ZeroconfServiceInfo` wurde aus `homeassistant.components.zeroconf` entfernt. Import in `config_flow.py` und `tests/test_discovery.py` auf `AsyncServiceInfo` umgestellt.
+- **Repairs-Imports verschoben**: `IssueSeverity`, `async_create_issue` und `async_delete_issue` wurden aus `homeassistant.components.repairs` in `homeassistant.helpers.issue_registry` verschoben. Import in `device.py` entsprechend aktualisiert.
+
+### Neue Features
+
+- **Diagnosedaten-Download**: Neues `diagnostics.py` Modul hinzugefügt. Über die Geräteseite in HA kann jetzt eine JSON-Datei mit vollständigen Debug-Informationen heruntergeladen werden (Konfiguration, Gerätestatus, Verbindungsmetriken, aktuelle Messwerte, Poll-Statistiken). Passwörter werden automatisch geschwärzt.
+
+### Dokumentation
+
+- **README bereinigt**: README.md auf das Wesentliche (Features + Schnellstart + Wiki-Links) reduziert. Alle Details wurden in das Wiki ausgelagert.
+- **Wiki aktualisiert**: Home-Seite, Sidebar und Changelog auf Version 1.0.3-alpha.2 aktualisiert.
+- **Neue Wiki-Seite Diagnostics**: Vollständige Dokumentation der Diagnosedaten-Funktion.
+
+---
+
 ## [1.0.3-alpha.1] – 2026-02-28 🔴 ALPHA
 
 ### Neue Features

--- a/docs/wiki/Diagnostics.md
+++ b/docs/wiki/Diagnostics.md
@@ -1,0 +1,196 @@
+# Diagnosedaten – Diagnostics
+
+> Mit dem eingebauten Diagnostics-Feature kannst du mit einem Klick alle relevanten Informationen über deinen Violet Pool Controller als JSON-Datei herunterladen – ideal für Bug-Reports und Troubleshooting.
+
+---
+
+## Was sind Diagnosedaten?
+
+Home Assistant bietet für Integrationen eine eingebaute Diagnostics-Funktion. Beim Klick auf **„Diagnosedaten herunterladen"** wird eine JSON-Datei erstellt, die alle wichtigen Informationen zum aktuellen Zustand der Integration enthält – ohne sensible Daten wie Passwörter.
+
+---
+
+## Diagnosedaten herunterladen
+
+1. Gehe zu **Einstellungen → Geräte & Dienste**
+2. Klicke auf **Violet Pool Controller**
+3. Wähle dein Gerät aus
+4. Klicke auf **„Diagnosedaten herunterladen"** (⬇️)
+5. Eine JSON-Datei wird gespeichert
+
+> Die Datei kann direkt als Anhang an ein [GitHub Issue](https://github.com/Xerolux/violet-hass/issues) angehängt werden.
+
+---
+
+## Inhalt der Diagnosedaten
+
+Die heruntergeladene JSON-Datei ist in folgende Sektionen aufgeteilt:
+
+### `integration`
+
+Basisinformationen zur Integration:
+
+```json
+"integration": {
+  "version": "1.0.3-alpha.2",
+  "domain": "violet_pool_controller"
+}
+```
+
+---
+
+### `config_entry`
+
+Alle Konfigurationseinstellungen. **Passwörter und Benutzernamen werden automatisch geschwärzt (`**REDACTED**`).**
+
+```json
+"config_entry": {
+  "title": "Violet Pool Controller • 50.0m³",
+  "entry_id": "abc123...",
+  "data": {
+    "host": "192.168.1.100",
+    "polling_interval": 10,
+    "timeout_duration": 10,
+    "retry_attempts": 3,
+    "use_ssl": false,
+    "verify_ssl": true,
+    "device_id": 1,
+    "device_name": "Violet Pool Controller",
+    "controller_name": "Hauptpool",
+    "active_features": ["pump", "heater", "solar", "dosing_ph"],
+    "password": "**REDACTED**"
+  },
+  "options": {}
+}
+```
+
+---
+
+### `device`
+
+Aktueller Status des Controllers:
+
+```json
+"device": {
+  "name": "Violet Pool Controller",
+  "controller_name": "Hauptpool",
+  "firmware": "1.1.9",
+  "device_id": 1,
+  "api_url": "192.168.1.100",
+  "use_ssl": false,
+  "available": true,
+  "consecutive_failures": 0,
+  "last_error": null
+}
+```
+
+| Feld | Bedeutung |
+|------|-----------|
+| `available` | `true` = Controller erreichbar |
+| `consecutive_failures` | Anzahl aufeinanderfolgender Verbindungsfehler (ab 5 wird der Controller als nicht verfügbar markiert) |
+| `last_error` | Letzter Fehlertext (null = kein Fehler) |
+| `firmware` | Firmware-Version des Controllers |
+
+---
+
+### `connection`
+
+Verbindungsmetriken und Gesundheitsstatus:
+
+```json
+"connection": {
+  "system_health_pct": 98.5,
+  "last_latency_ms": 207.3,
+  "average_latency_ms": 195.1,
+  "total_api_requests": 432,
+  "api_request_rate_per_min": 6.0,
+  "seconds_since_last_update": 4.2,
+  "last_update_success": true
+}
+```
+
+| Feld | Bedeutung |
+|------|-----------|
+| `system_health_pct` | Gesundheitsscore 0–100 % |
+| `last_latency_ms` | Antwortzeit des letzten API-Calls in ms |
+| `average_latency_ms` | Durchschnitt der letzten 60 Messungen |
+| `total_api_requests` | Gesamtanzahl API-Requests seit HA-Start |
+| `api_request_rate_per_min` | Aktuelle Request-Rate pro Minute |
+| `seconds_since_last_update` | Sekunden seit dem letzten erfolgreichen Update |
+| `last_update_success` | `true` = letztes Update erfolgreich |
+
+---
+
+### `current_data`
+
+Snapshot aller aktuellen Messwerte vom Controller (z. B. Temperaturen, pH, ORP, Pumpenstatus):
+
+```json
+"current_data": {
+  "onewire1_value": 27.3,
+  "onewire2_value": 24.1,
+  "pH_value": 7.25,
+  "orp_value": 685,
+  "PUMP": 1,
+  "HEATER": 0,
+  "FW": "1.1.9",
+  ...
+}
+```
+
+> Der Inhalt hängt von deinem Controller und den aktivierten Features ab. Alle verfügbaren Sensoren werden hier aufgelistet.
+
+---
+
+### `poll_statistics`
+
+Statistiken über die bisherigen Datenabfragen:
+
+```json
+"poll_statistics": {
+  "total_polls": 432,
+  "first_poll": "2026-03-02T05:32:50",
+  "last_poll": "2026-03-02T06:05:10",
+  "avg_data_points": 403.0
+}
+```
+
+| Feld | Bedeutung |
+|------|-----------|
+| `total_polls` | Gesamtanzahl abgeschlossener Polls seit Start |
+| `first_poll` | Zeitstempel des ersten Polls |
+| `last_poll` | Zeitstempel des letzten Polls |
+| `avg_data_points` | Durchschnittliche Anzahl empfangener Datenpunkte pro Poll |
+
+---
+
+## Datenschutz & Sicherheit
+
+Die Diagnosedaten werden **nur lokal erzeugt** und nur dann weitergegeben, wenn du die Datei manuell hochlädst. Folgende Felder werden automatisch geschwärzt:
+
+| Feld | Behandlung |
+|------|-----------|
+| `password` | `**REDACTED**` |
+| `username` | `**REDACTED**` |
+| Alle anderen Felder | Klartext |
+
+> Die IP-Adresse des Controllers (`host`) ist in den Diagnosedaten sichtbar. Falls du sie nicht teilen möchtest, ersetze sie manuell im JSON-Editor, bevor du die Datei hochlädst.
+
+---
+
+## Diagnosedaten für einen Bug-Report nutzen
+
+1. Diagnosedaten herunterladen (siehe oben)
+2. Datei ggf. in einem Texteditor öffnen und IP anonymisieren
+3. [Neues Issue erstellen](https://github.com/Xerolux/violet-hass/issues/new/choose)
+4. Fehlerbeschreibung, HA-Version und Integrations-Version angeben
+5. JSON-Datei als Anhang hinzufügen
+
+---
+
+## Verwandte Seiten
+
+- [Troubleshooting](Troubleshooting) – Häufige Probleme & Lösungen
+- [Erweiterte Protokollierung](Erweiterte-Protokollierung) – Debug-Logs aktivieren
+- [Fehler-Codes](Error-Codes) – Controller-Fehlercodes erklärt
+- [FAQ](FAQ) – Häufige Fragen

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -13,8 +13,9 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 |---------|---------|
 | **Protokoll** | HTTP/HTTPS, lokales Polling |
 | **HA-Mindestversion** | 2025.12.0 |
+| **Getestet bis** | 2026.x (aktuell) |
 | **Python** | 3.12+ |
-| **Version** | 1.0.3-alpha.1 |
+| **Version** | 1.0.3-alpha.2 |
 | **Lizenz** | MIT |
 | **Sprachen** | DE, EN, ES, FR, IT, NL, PL, PT, RU, ZH |
 
@@ -29,8 +30,8 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 │   Pumpe      │   Heizung    │   Solar      │ Dosierung  │
 │  (3 Stufen)  │ (Thermostat) │ (PV-Surplus) │ pH/Cl/ORP  │
 ├──────────────┼──────────────┼──────────────┼────────────┤
-│   Beleucht.  │   Abdeckung  │  Digit. I/O  │ Kalibrierung│
-│ (DMX 1-8)   │  (Cover)     │  (DI1-DI8)   │ History    │
+│   Beleucht.  │   Abdeckung  │  Digit. I/O  │ Diagnose   │
+│ (DMX 1-8)   │  (Cover)     │  (DI1-DI8)   │ Download   │
 ├──────────────┴──────────────┴──────────────┴────────────┤
 │  100% lokal · Multi-Controller · SSL/TLS · Rate Limiting │
 └─────────────────────────────────────────────────────────┘
@@ -68,10 +69,11 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 ### Ich habe ein Problem
 
 1. **[Troubleshooting](Troubleshooting)** – Häufige Probleme & Lösungen
-2. **[Erweiterte Protokollierung](Erweiterte-Protokollierung)** – Diagnose-Tools & Log-Export
-3. **[Fehler-Codes](Error-Codes)** – Controller-Fehlercodes erklärt
-4. **[FAQ](FAQ)** – 50+ häufige Fragen
-5. **[GitHub Issues](https://github.com/Xerolux/violet-hass/issues)** – Bug-Reports
+2. **[Diagnosedaten herunterladen](Diagnostics)** – JSON-Export für Bug-Reports
+3. **[Erweiterte Protokollierung](Erweiterte-Protokollierung)** – Diagnose-Tools & Log-Export
+4. **[Fehler-Codes](Error-Codes)** – Controller-Fehlercodes erklärt
+5. **[FAQ](FAQ)** – 50+ häufige Fragen
+6. **[GitHub Issues](https://github.com/Xerolux/violet-hass/issues)** – Bug-Reports
 
 ### Ich will mehrere Controller
 
@@ -88,9 +90,9 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 ```
 Home Assistant
     │
-    ├── VioletPoolDataUpdateCoordinator (polling, 20s default)
+    ├── VioletPoolDataUpdateCoordinator (polling, 10s default)
     │       │
-    │       ├── VioletPoolAPI (aiohttp, rate-limited, retry-logic)
+    │       ├── VioletPoolAPI (aiohttp, rate-limited, retry-logic, SSL)
     │       │       │
     │       │       └── Violet Pool Controller (HTTP/HTTPS)
     │       │               GET /getReadings?ALL
@@ -99,7 +101,9 @@ Home Assistant
     │       │
     │       └── Entities (sensors, switches, climate, cover, number)
     │
-    └── Services (control_pump, smart_dosing, manage_pv_surplus, ...)
+    ├── Services (control_pump, smart_dosing, manage_pv_surplus, ...)
+    │
+    └── Diagnostics (Diagnosedaten herunterladen via HA UI)
 ```
 
 ### Sicherheits-Features
@@ -131,6 +135,17 @@ Home Assistant
 
 ---
 
+## HA 2026 Kompatibilität
+
+Diese Integration ist vollständig mit Home Assistant 2026.x kompatibel:
+
+| Problem | Status | Fix |
+|---------|--------|-----|
+| `ZeroconfServiceInfo` entfernt | ✅ Behoben | `AsyncServiceInfo` aus `homeassistant.components.zeroconf` |
+| `IssueSeverity` aus `components.repairs` entfernt | ✅ Behoben | Umzug nach `homeassistant.helpers.issue_registry` |
+
+---
+
 ## Links & Ressourcen
 
 | Ressource | Link |
@@ -146,5 +161,5 @@ Home Assistant
 
 ---
 
-*Diese Wiki dokumentiert Version **1.0.3-alpha.1** des Violet Pool Controller Addons.*
-*Zuletzt aktualisiert: 2026-02-28*
+*Diese Wiki dokumentiert Version **1.0.3-alpha.2** des Violet Pool Controller Addons.*
+*Zuletzt aktualisiert: 2026-03-02*

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -21,6 +21,7 @@
 
 ## 🔧 Betrieb & Wartung
 - [Troubleshooting](Troubleshooting)
+- [Diagnosedaten](Diagnostics)
 - [Erweiterte Protokollierung](Erweiterte-Protokollierung)
 - [Fehler-Codes](Error-Codes)
 - [Security & SSL](Security)
@@ -34,7 +35,7 @@
 
 ---
 
-**Version:** 1.0.3-alpha.1
+**Version:** 1.0.3-alpha.2
 **HA:** 2025.12.0+ (getestet bis 2026.x)
 
 [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/)


### PR DESCRIPTION
README.md:
- Removed all detail sections (config, entities, automations, troubleshooting) that are already covered in the wiki
- Added prominent wiki link table pointing to every wiki page
- Kept: badges, feature overview, 3-step quickstart, support, device info

docs/wiki/Home.md:
- Updated version to 1.0.3-alpha.2, date to 2026-03-02
- Added HA 2026 compatibility table (ZeroconfServiceInfo, repairs imports)
- Added Diagnostics to navigation and architecture diagram

docs/wiki/_Sidebar.md:
- Added Diagnosedaten (Diagnostics) link under Betrieb & Wartung
- Updated version to 1.0.3-alpha.2

docs/wiki/Diagnostics.md (new):
- Full documentation of the diagnostics download feature
- Describes all JSON sections: integration, config_entry, device, connection, current_data, poll_statistics
- Explains redacted fields, privacy notes, bug-report workflow

docs/wiki/Changelog.md:
- Added 1.0.3-alpha.2 entry with all fixes and new features

## Summary by Sourcery

Streamline the README to a concise feature and quickstart overview that delegates detailed usage to the wiki, and expand the wiki with diagnostics documentation and Home Assistant 2026 compatibility notes.

Documentation:
- Condense README to core features, quickstart, prerequisites, and a structured wiki navigation table, moving detailed setup and troubleshooting content into the wiki.
- Update wiki home and sidebar to version 1.0.3-alpha.2, add diagnostics and HA 2026 compatibility sections, and document the diagnostics JSON export feature on a dedicated page.
- Extend the changelog with a 1.0.3-alpha.2 entry describing diagnostics, documentation updates, and HA 2026 compatibility fixes.