### PR TITLE
chore: bump version to 1.0.3-beta.1

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -24,7 +24,7 @@ from .const_sensors import *
 # =============================================================================
 
 DOMAIN = "violet_pool_controller"
-INTEGRATION_VERSION = "1.0.3-alpha.2"
+INTEGRATION_VERSION = "1.0.3-beta.1"
 MANUFACTURER = "PoolDigital GmbH & Co. KG"
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
   "requirements": ["aiohttp>=3.10.0"],
-  "version": "1.0.3-alpha.2",
+  "version": "1.0.3-beta.1",
   "zeroconf": [
     "_http._tcp.local.",
     "_violet-controller._tcp.local."

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -4,6 +4,16 @@
 
 ---
 
+## [1.0.3-beta.1] – 2026-03-02 🟡 BETA
+
+### Versionsschritt Alpha → Beta
+
+- Alle bekannten HA 2026 Kompatibilitätsfehler behoben.
+- Diagnosedaten-Download Feature fertiggestellt.
+- Dokumentation (README + Wiki) vollständig überarbeitet und aktualisiert.
+
+---
+
 ## [1.0.3-alpha.2] – 2026-03-02 🔴 ALPHA
 
 ### Bugfixes (HA 2026 Kompatibilität)

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -37,7 +37,7 @@ Beiträge sind herzlich willkommen – egal ob Bug-Reports, Feature-Requests, Do
 
 2. ENVIRONMENT
    - Home Assistant Version: 2026.x.x (Minimum: 2025.12.0)
-   - Integration Version: 1.0.3-alpha.1
+   - Integration Version: 1.0.3-beta.1
    - Controller Firmware: x.x.x
    - Python Version: 3.12+
 

--- a/docs/wiki/Diagnostics.md
+++ b/docs/wiki/Diagnostics.md
@@ -32,7 +32,7 @@ Basisinformationen zur Integration:
 
 ```json
 "integration": {
-  "version": "1.0.3-alpha.2",
+  "version": "1.0.3-beta.1",
   "domain": "violet_pool_controller"
 }
 ```

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -15,7 +15,7 @@ Das **Violet Pool Controller Home Assistant Integration** verbindet [Home Assist
 | **HA-Mindestversion** | 2025.12.0 |
 | **Getestet bis** | 2026.x (aktuell) |
 | **Python** | 3.12+ |
-| **Version** | 1.0.3-alpha.2 |
+| **Version** | 1.0.3-beta.1 |
 | **Lizenz** | MIT |
 | **Sprachen** | DE, EN, ES, FR, IT, NL, PL, PT, RU, ZH |
 
@@ -161,5 +161,5 @@ Diese Integration ist vollständig mit Home Assistant 2026.x kompatibel:
 
 ---
 
-*Diese Wiki dokumentiert Version **1.0.3-alpha.2** des Violet Pool Controller Addons.*
+*Diese Wiki dokumentiert Version **1.0.3-beta.1** des Violet Pool Controller Addons.*
 *Zuletzt aktualisiert: 2026-03-02*

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -59,9 +59,9 @@ Hier findest du alles, was du brauchst - von der Installation bis zur Deinstalla
 
 ## 🔄 Auf dem neuesten Stand
 
-Diese Wiki dokumentiert **Version 1.0.3-alpha.1** des Violet Pool Controller Home Assistant Addons.
+Diese Wiki dokumentiert **Version 1.0.3-beta.1** des Violet Pool Controller Home Assistant Addons.
 
-Letzte Aktualisierung: **2026-02-28**
+Letzte Aktualisierung: **2026-03-02**
 
 ---
 

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,3 +1,3 @@
 ---
-**Violet Pool Controller** v1.0.3-alpha.1 · [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/) · Lizenz: MIT · Requires HA 2025.12.0+ (getestet bis 2026.x)
+**Violet Pool Controller** v1.0.3-beta.1 · [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/) · Lizenz: MIT · Requires HA 2025.12.0+ (getestet bis 2026.x)
 Developed with ❤️ for the Home Assistant & Pool Community · [Buy Me a Coffee](https://buymeacoffee.com/xerolux)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -35,7 +35,7 @@
 
 ---
 
-**Version:** 1.0.3-alpha.2
+**Version:** 1.0.3-beta.1
 **HA:** 2025.12.0+ (getestet bis 2026.x)
 
 [GitHub](https://github.com/Xerolux/violet-hass) · [Issues](https://github.com/Xerolux/violet-hass/issues) · [HACS](https://hacs.xyz/)


### PR DESCRIPTION
Updated all version references from alpha to beta:
- custom_components/violet_pool_controller/const.py
- custom_components/violet_pool_controller/manifest.json
- docs/wiki/Home.md, _Sidebar.md, _Footer.md, README.md
- docs/wiki/Contributing.md, Diagnostics.md
- docs/wiki/Changelog.md (new beta.1 entry added)

## Summary by Sourcery

Bump Violet Pool Controller integration from 1.0.3-alpha to 1.0.3-beta.1 and align documentation and metadata with the new beta release.

New Features:
- Introduce a 1.0.3-beta.1 release that finalizes the diagnostics download feature and marks HA 2026 compatibility as complete.

Enhancements:
- Update integration constants and manifest metadata to version 1.0.3-beta.1 for the Violet Pool Controller component.

Documentation:
- Update wiki, README, sidebar, footer, and contributing documentation to reference version 1.0.3-beta.1 and the latest update date.
- Add a 1.0.3-beta.1 changelog entry describing the move from alpha to beta, completed diagnostics feature, and updated documentation.