### PR TITLE
Fix over-broad zeroconf discovery

### DIFF
--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -1,17 +1,26 @@
 {
   "domain": "violet_pool_controller",
   "name": "Violet Pool Controller",
-  "codeowners": ["@xerolux"],
+  "codeowners": [
+    "@xerolux"
+  ],
   "config_flow": true,
-  "dependencies": ["repairs"],
+  "dependencies": [
+    "repairs"
+  ],
   "documentation": "https://github.com/xerolux/violet-hass",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
-  "requirements": ["aiohttp>=3.10.0"],
+  "requirements": [
+    "aiohttp>=3.10.0"
+  ],
   "version": "1.0.3-beta.1",
   "zeroconf": [
-    "_http._tcp.local.",
+    {
+      "type": "_http._tcp.local.",
+      "name": "violet*"
+    },
     "_violet-controller._tcp.local."
   ]
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,7 @@
 
 import pytest
 from unittest.mock import MagicMock
-from homeassistant.core import HomeAssistant, Config
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -65,7 +65,7 @@ async def test_export_diagnostic_logs_failure(hass: HomeAssistant, device_regist
 
 
 # Mock Config class to simulate real behavior (no .version attribute)
-class RealConfig(Config):
+class RealConfig:
     def __init__(self):
         self.components = {"http", "websocket_api"}
         self.time_zone = "UTC"


### PR DESCRIPTION
Limits the `_http._tcp.local.` zeroconf discovery filter in `manifest.json` to names matching `violet*`. This prevents the integration from trying to set up arbitrary devices on the user's network that happen to expose a generic HTTP server via mDNS. Also includes a minor fix for a failing test module caused by a deprecated Home Assistant import.

---
*PR created automatically by Jules for task [13817346199868766087](https://jules.google.com/task/13817346199868766087) started by @Xerolux*

## Summary by Sourcery

Restrict zeroconf discovery to Violet-specific HTTP services and update tests to align with current Home Assistant APIs.

Enhancements:
- Limit zeroconf discovery to HTTP services whose mDNS name matches the Violet controller pattern.

Tests:
- Adjust test configuration stub to avoid relying on deprecated Home Assistant imports.