### PR TITLE
Add Stale, Status Check, and Auto-Label GitHub Actions

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,25 +1,16 @@
 name: Auto Label PR
 
 on:
-  # Runs only on pull_request_target due to having access to a App token.
-  # This means PRs from forks will not be able to alter this workflow to get the tokens
   pull_request_target:
-    types: [labeled, opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
 
 permissions:
   pull-requests: write
   contents: read
 
-env:
-  SMALL_PR_THRESHOLD: 30
-  MAX_LABELS: 15
-  TOO_BIG_THRESHOLD: 1000
-  COMPONENT_LABEL_THRESHOLD: 10
-
 jobs:
   label:
     runs-on: ubuntu-latest
-    if: github.event.action != 'labeled' || github.event.sender.type != 'Bot'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,32 @@
+name: Auto Label PR
+
+on:
+  # Runs only on pull_request_target due to having access to a App token.
+  # This means PRs from forks will not be able to alter this workflow to get the tokens
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize, edited]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+env:
+  SMALL_PR_THRESHOLD: 30
+  MAX_LABELS: 15
+  TOO_BIG_THRESHOLD: 1000
+  COMPONENT_LABEL_THRESHOLD: 10
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.sender.type != 'Bot'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Auto Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  issues: write
 
 jobs:
   label:

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -19,38 +19,25 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |
-            👋 Thank you for opening your first issue! 
-            
+            👋 Thank you for opening your first issue!
+
             Please provide as much detail as possible:
             - Home Assistant version
             - Integration version
             - Controller firmware version
             - Error logs (if applicable)
-            
+
             This helps us understand and resolve the issue faster.
           pr-message: |
-            👋 Thank you for your first pull request! 
-            
+            👋 Thank you for your first pull request!
+
             Please ensure:
             - ✅ Code follows our style guidelines
             - ✅ All tests pass
             - ✅ Documentation is updated (if needed)
             - ✅ docs/CHANGELOG.md is updated
-            
-            A maintainer will review your PR soon!
 
-  labeler:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          
-      - uses: actions/labeler@v6
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labeler.yml
+            A maintainer will review your PR soon!
 
   dependency-review:
     runs-on: ubuntu-latest
@@ -59,12 +46,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          
+
       - uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
           fail-on-severity: moderate
-          
+
   size-label:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,65 @@
+---
+name: Stale
+
+on:
+  schedule:
+    - cron: "30 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stale
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          debug-only: ${{ github.ref != 'refs/heads/main' }} # Dry-run when not run on main branch
+          remove-stale-when-updated: true
+          operations-per-run: 400
+
+          # The 90 day stale policy for PRs
+          # - PRs
+          # - No PRs marked as "not-stale"
+          # - No Issues (see below)
+          days-before-pr-stale: 90
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          exempt-pr-labels: "not-stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. This
+            pull request has been automatically marked as stale because of that
+            and will be closed if no further activity occurs within 7 days.
+
+            If you are the author of this PR, please leave a comment if you want
+            to keep it open. Also, please rebase your PR onto the latest dev
+            branch to ensure that it's up to date with the latest changes.
+
+            Thank you for your contribution!
+
+          # The 90 day stale policy for Issues
+          # - Issues
+          # - No Issues marked as "not-stale"
+          # - No PRs (see above)
+          days-before-issue-stale: 90
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          exempt-issue-labels: "not-stale"
+          stale-issue-message: >
+            There hasn't been any activity on this issue recently. Due to the
+            high number of incoming GitHub notifications, we have to clean some
+            of the old issues, as many of them have already been resolved with
+            the latest updates.
+
+            Please make sure to update to the latest integration version and
+            check if that solves the issue. Let us know if that works for you by
+            adding a comment 👍
+
+            This issue has now been marked as stale and will be closed if no
+            further activity occurs. Thank you for your contributions.

--- a/.github/workflows/status-check-labels.yml
+++ b/.github/workflows/status-check-labels.yml
@@ -1,0 +1,31 @@
+name: Status check labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  check:
+    name: Check ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - needs-docs
+          - merge-after-release
+          - chained-pr
+    steps:
+      - name: Check for ${{ matrix.label }} label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const hasLabel = labels.find(label => label.name === '${{ matrix.label }}');
+            if (hasLabel) {
+              core.setFailed('Pull request cannot be merged, it is labeled as ${{ matrix.label }}');
+            }

--- a/.github/workflows/status-check-labels.yml
+++ b/.github/workflows/status-check-labels.yml
@@ -18,14 +18,17 @@ jobs:
     steps:
       - name: Check for ${{ matrix.label }} label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          LABEL: ${{ matrix.label }}
         with:
           script: |
+            const labelToCheck = process.env.LABEL;
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
-            const hasLabel = labels.find(label => label.name === '${{ matrix.label }}');
+            const hasLabel = labels.find(label => label.name === labelToCheck);
             if (hasLabel) {
-              core.setFailed('Pull request cannot be merged, it is labeled as ${{ matrix.label }}');
+              core.setFailed(`Pull request cannot be merged, it is labeled as ${labelToCheck}`);
             }


### PR DESCRIPTION
This adds essential GitHub Actions to maintain PR and issue hygiene. It includes a `stale` workflow to handle inactive items, a `status-check-labels` workflow to prevent accidental merges of PRs that are explicitly marked as unready, and a dedicated `auto-label-pr` workflow for path-based PR labeling.

---
*PR created automatically by Jules for task [11086095462309742945](https://jules.google.com/task/11086095462309742945) started by @Xerolux*

## Summary by Sourcery

Introduce dedicated GitHub Actions workflows for stale item management, PR auto-labeling, and label-based merge blocking while simplifying existing PR management.

New Features:
- Add a scheduled stale workflow to automatically mark and close inactive issues and pull requests.
- Add an auto-label PR workflow that applies and syncs labels based on repository configuration for incoming pull requests.
- Add a status-check-labels workflow that fails PR checks when specific blocking labels are present.

Enhancements:
- Refine PR management messaging for first-time contributors and remove the inline labeler job in favor of a dedicated auto-label workflow.

CI:
- Add new GitHub Actions workflows for stale triage, path-based PR auto-labeling, and label-enforced status checks, and adjust existing PR management configuration.