### PR TITLE
docs: add My Home Assistant badge for HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
 ## ⚡ Schnellstart
 
 **1. HACS – Integration hinzufügen**
+
+<a href="https://my.home-assistant.io/redirect/hacs_repository/?repository=https%3A%2F%2Fgithub.com%2FXerolux%2Fviolet-hass&owner=Xerolux&category=Integration" target="_blank" rel="noreferrer noopener"><img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open your Home Assistant instance and open a repository inside the Home Assistant Community Store." /></a>
+
 ```
 HACS → Integrationen → ⋮ → Benutzerdefinierte Repositories
 URL: https://github.com/xerolux/violet-hass  |  Kategorie: Integration


### PR DESCRIPTION
This PR adds the "My Home Assistant" badge to the `README.md` file under the quick start section. This allows users to directly open the Home Assistant Community Store and install the integration with a single click. The URL parameter was correctly configured as `category=Integration`.

---
*PR created automatically by Jules for task [3402695434268543970](https://jules.google.com/task/3402695434268543970) started by @Xerolux*

## Summary by Sourcery

Documentation:
- Document a one-click HACS installation path using a My Home Assistant badge in the quick start guide.