### PR TITLE
chore: Update quality scale to Silver

### DIFF
--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -12,7 +12,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
-  "quality_scale": "platinum",
+  "quality_scale": "silver",
   "requirements": [
     "aiohttp>=3.10.0"
   ],

--- a/custom_components/violet_pool_controller/quality_scale.yaml
+++ b/custom_components/violet_pool_controller/quality_scale.yaml
@@ -61,52 +61,52 @@ rules:
 
   # Gold
   devices:
-    status: done
+    status: todo
   diagnostics:
-    status: done
+    status: todo
   discovery-update-info:
-    status: done
+    status: todo
   discovery:
-    status: done
+    status: todo
   docs-data-update:
-    status: done
+    status: todo
   docs-examples:
-    status: done
+    status: todo
   docs-known-limitations:
-    status: done
+    status: todo
   docs-supported-devices:
-    status: done
+    status: todo
   docs-supported-functions:
-    status: done
+    status: todo
   docs-troubleshooting:
-    status: done
+    status: todo
   docs-use-cases:
-    status: done
+    status: todo
   dynamic-devices:
-    status: done
+    status: todo
   entity-category:
-    status: done
+    status: todo
   entity-device-class:
-    status: done
+    status: todo
   entity-disabled-by-default:
-    status: done
+    status: todo
   entity-translations:
-    status: done
+    status: todo
   exception-translations:
-    status: done
+    status: todo
   icon-translations:
-    status: done
+    status: todo
   reconfiguration-flow:
-    status: done
+    status: todo
   repair-issues:
-    status: done
+    status: todo
   stale-devices:
-    status: done
+    status: todo
 
   # Platinum
   async-dependency:
-    status: done
+    status: todo
   inject-websession:
-    status: done
+    status: todo
   strict-typing:
-    status: done
+    status: todo


### PR DESCRIPTION
Updates the quality scale in `manifest.json` and `quality_scale.yaml` to accurately reflect the actual implementation status (Silver), as identified by the project's quality audits.

---
*PR created automatically by Jules for task [9430099777785269687](https://jules.google.com/task/9430099777785269687) started by @Xerolux*

## Summary by Sourcery

Align the integration's declared quality level with its actual Silver status.

Enhancements:
- Update the integration manifest to declare a Silver quality scale instead of Platinum.
- Adjust quality_scale.yaml criteria statuses so Gold and Platinum items are marked as remaining work rather than completed.