### PR TITLE
Fix: Remove failing GitHub Discussion action from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,23 +533,6 @@ jobs:
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
-  create-announcement:
-    needs: [prepare-release, update-changelog]
-    runs-on: ubuntu-latest
-    if: |
-      success() &&
-      needs.prepare-release.outputs.is_draft != 'true' &&
-      needs.prepare-release.outputs.release_type == 'stable'
-    steps:
-      - name: Create GitHub Discussion
-        uses: abirismyname/create-discussion@v1.x
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository-id: ${{ vars.REPOSITORY_ID }}
-          category-id: ${{ vars.DISCUSSION_CATEGORY_ID }}
-          title: "🎉 Release v${{ needs.prepare-release.outputs.version }} - Violet Pool Controller"
-          body: ${{ needs.prepare-release.outputs.release-notes }}
-
   create-summary:
     needs: [prepare-release, update-changelog]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed the `create-announcement` job from the release workflow to fix the failing action (`Warning: Unexpected input(s) 'github-token'`). The user indicated this action is no longer required.

---
*PR created automatically by Jules for task [11483174018715396599](https://jules.google.com/task/11483174018715396599) started by @Xerolux*

## Summary by Sourcery

CI:
- Remove the create-announcement job from the release workflow that created a GitHub Discussion for stable releases.