### PR TITLE
hacs and hassfest workflows on release

### DIFF
--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -1,0 +1,21 @@
+name: HACS Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    name: HACS Action
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/hassfest-validation.yml
+++ b/.github/workflows/hassfest-validation.yml
@@ -1,0 +1,19 @@
+name: Hassfest Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    name: Hassfest Action
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hassfest Action
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,14 +76,6 @@ jobs:
             --cov-report=term-missing
         continue-on-error: true
         
-      - name: Validate with hassfest
-        uses: home-assistant/actions/hassfest@master
-        
-      - name: Validate with HACS
-        uses: hacs/action@main
-        with:
-          category: integration
-          
       - name: Create validation summary
         if: always()
         run: |


### PR DESCRIPTION
Added the `release: types: [published]` trigger to both `.github/workflows/hacs-validation.yml` and `.github/workflows/hassfest-validation.yml` so that a fresh, independent run ID is generated specifically for the release tag, which helps satisfy HACS default repository submission requirements.

## Summary by Sourcery

Trigger HACS and Hassfest validation workflows when a release is published, in addition to pushes, pull requests, and manual dispatch.

CI:
- Run HACS validation workflow on published release tags to generate a dedicated run for the release.
- Run Hassfest validation workflow on published release tags to generate a dedicated run for the release.