### PR TITLE
ci: improve trigger reliability for validation workflows

### DIFF
--- a/.github/workflows/hacs-validation.yml
+++ b/.github/workflows/hacs-validation.yml
@@ -1,0 +1,22 @@
+name: HACS Validation
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  release:
+    types: [published, prereleased]
+  workflow_dispatch:
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    name: HACS Action
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/hassfest-validation.yml
+++ b/.github/workflows/hassfest-validation.yml
@@ -1,0 +1,20 @@
+name: Hassfest Validation
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  release:
+    types: [published, prereleased]
+  workflow_dispatch:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    name: Hassfest Action
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hassfest Action
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,14 +76,6 @@ jobs:
             --cov-report=term-missing
         continue-on-error: true
         
-      - name: Validate with hassfest
-        uses: home-assistant/actions/hassfest@master
-        
-      - name: Validate with HACS
-        uses: hacs/action@main
-        with:
-          category: integration
-          
       - name: Create validation summary
         if: always()
         run: |


### PR DESCRIPTION
Add `prereleased` to the release trigger and `tags: ['v*']` to the push trigger for `.github/workflows/hacs-validation.yml` and `.github/workflows/hassfest-validation.yml` to guarantee they run when tags or beta releases are created.

## Summary by Sourcery

Update CI validation workflows to also run on version tags and prerelease events.

CI:
- Trigger HACS and Hassfest validation workflows on version tags matching 'v*' in addition to the main branch.
- Include prereleased GitHub release events as triggers for HACS and Hassfest validation workflows alongside published releases.