### PR TITLE
Update API to 0.0.2 and Add Auto-Update Workflow

### DIFF
--- a/.github/workflows/update-api-dependency.yml
+++ b/.github/workflows/update-api-dependency.yml
@@ -1,0 +1,82 @@
+name: Update API Dependency
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight
+  workflow_dispatch:
+
+jobs:
+  update-dependency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch latest violet-poolController-api version
+        id: fetch_version
+        run: |
+          LATEST_VERSION=$(curl -s https://pypi.org/pypi/violet-poolController-api/json | jq -r .info.version)
+          if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
+            echo "Failed to fetch version from PyPI"
+            exit 1
+          fi
+          echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest version on PyPI: $LATEST_VERSION"
+
+      - name: Update manifest.json
+        id: update_manifest
+        env:
+          MANIFEST_FILE: custom_components/violet_pool_controller/manifest.json
+          LATEST_VERSION: ${{ steps.fetch_version.outputs.latest_version }}
+        run: |
+          python3 -c "
+          import json
+          import sys
+          import os
+
+          manifest_file = os.environ['MANIFEST_FILE']
+          latest_ver = os.environ['LATEST_VERSION']
+          github_output = os.environ['GITHUB_OUTPUT']
+
+          with open(manifest_file, 'r') as f:
+              data = json.load(f)
+
+          changed = False
+          new_reqs = []
+
+          for req in data.get('requirements', []):
+              if req.startswith('violet-poolController-api=='):
+                  current_ver = req.split('==')[1]
+                  if current_ver != latest_ver:
+                      new_reqs.append(f'violet-poolController-api=={latest_ver}')
+                      changed = True
+                      print(f'Updating from {current_ver} to {latest_ver}')
+                  else:
+                      new_reqs.append(req)
+              else:
+                  new_reqs.append(req)
+
+          if changed:
+              data['requirements'] = new_reqs
+              with open(manifest_file, 'w') as f:
+                  json.dump(data, f, indent=2)
+                  f.write('\n')
+              with open(github_output, 'a') as f:
+                  f.write('changed=true\n')
+          else:
+              with open(github_output, 'a') as f:
+                  f.write('changed=false\n')
+          "
+
+      - name: Create Pull Request
+        if: steps.update_manifest.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        env:
+          LATEST_VERSION: ${{ steps.fetch_version.outputs.latest_version }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): update violet-poolController-api to ${{ env.LATEST_VERSION }}"
+          title: "chore(deps): update violet-poolController-api to ${{ env.LATEST_VERSION }}"
+          body: "Automated PR to update the `violet-poolController-api` dependency in `manifest.json` to the latest version on PyPI (${{ env.LATEST_VERSION }})."
+          branch: "update-api-dependency"
+          delete-branch: true

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -15,7 +15,7 @@
   "quality_scale": "platinum",
   "requirements": [
     "aiohttp>=3.10.0",
-    "violet-poolController-api==0.0.1"
+    "violet-poolController-api==0.0.2"
   ],
   "version": "1.0.3",
   "zeroconf": [


### PR DESCRIPTION
Update violet-poolController-api to 0.0.2 and create a workflow to ensure we always use the latest version via automated pull requests.

---
*PR created automatically by Jules for task [2261087749228281711](https://jules.google.com/task/2261087749228281711) started by @Xerolux*

## Summary by Sourcery

Update the violet-poolController Home Assistant integration to use the latest API package and introduce automation to keep this dependency up to date via scheduled pull requests.

Build:
- Bump violet-poolController-api dependency in the integration manifest from 0.0.1 to 0.0.2.

CI:
- Add a scheduled GitHub Actions workflow that updates the violet-poolController-api version in manifest.json and opens an automated pull request when a new version is available.