### PR TITLE
Update dependencies for HA 2026.3 compatibility

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,10 +28,10 @@ jobs:
           - "2026.3.1"
     
     steps:
-      - uses: actions/checkout@v6
-      
+      - uses: actions/checkout@v4
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           
@@ -39,12 +39,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install homeassistant==${{ matrix.home-assistant-version }}
-          pip install aiohttp>=3.8.0
+          pip install "aiohttp>=3.11.0"
           
       - name: Install dev dependencies
         run: |
-          pip install ruff mypy pytest pytest-cov pytest-asyncio
-          pip install pytest-homeassistant-custom-component>=0.13.317
+          pip install "ruff>=0.15.0" "mypy>=1.15.0" "pytest>=9.0.0" "pytest-cov>=6.0.0" "pytest-asyncio>=1.0.0"
+          pip install "pytest-homeassistant-custom-component>=0.13.109"
           
       - name: Lint with Ruff
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,8 +301,8 @@ GitHub workflow `.github/workflows/validate.yml` runs:
 - Ruff linting
 - Mypy type checking
 - Full test suite with pytest
-- Tests against Home Assistant 2025.12.0
-- Python 3.13 environment
+- Tests against Home Assistant 2026.3.1
+- Python 3.14 environment
 
 ## Translation Files
 
@@ -381,7 +381,7 @@ violet-hass/
   - New Home Assistant version is released
   - New Python version is released
   - CI/CD pipeline fails due to compatibility issues
-- **Current version:** `>=0.13.317` (Python 3.14+ compatible)
+- **Current version:** `>=0.13.109` (Python 3.14+ compatible)
 - **Update command:** `pip install --upgrade pytest-homeassistant-custom-component`
 
 ### Code Style
@@ -467,17 +467,17 @@ Located in `.github/workflows/`:
 ## Dependencies
 
 **Runtime** (from `requirements.txt`):
-- `homeassistant>=2025.12.0` - Minimum Home Assistant version (HA 2026 ready)
-- `aiohttp>=3.10.0` - Async HTTP client
-- `voluptuous>=0.14.2` - Data validation
+- `homeassistant>=2026.3.0` - Minimum Home Assistant version
+- `aiohttp>=3.11.0` - Async HTTP client
+- `voluptuous>=0.15.0` - Data validation
 
 **Development** (from `requirements-dev.txt`):
-- `ruff>=0.1.0` - Linter and formatter
-- `mypy>=1.7.0` - Static type checker
-- `pytest>=7.4.0` - Test framework
-- `pytest-cov>=4.1.0` - Coverage plugin
-- `pytest-asyncio>=0.21.0` - Async test support
-- `pytest-homeassistant-custom-component>=0.13.0` - HA test helpers
+- `ruff>=0.15.0` - Linter and formatter
+- `mypy>=1.15.0` - Static type checker
+- `pytest>=9.0.0` - Test framework
+- `pytest-cov>=6.0.0` - Coverage plugin
+- `pytest-asyncio>=1.0.0` - Async test support
+- `pytest-homeassistant-custom-component>=0.13.109` - HA test helpers
 
 ## Important Notes
 
@@ -501,6 +501,6 @@ Located in `.github/workflows/`:
 
 8. **Code Quality**: Always run `ruff check --fix` before committing. The integration maintains 0 ruff errors.
 
-9. **Home Assistant Compatibility**: Integration requires HA 2025.12.0+ and is tested against HA 2026.x. Use modern type annotations (`X | None` not `Optional[X]`) and `collections.abc` imports.
+9. **Home Assistant Compatibility**: Integration requires HA 2026.3.0+ and is tested against HA 2026.3.x. Use modern type annotations (`X | None` not `Optional[X]`) and `collections.abc` imports.
 
 10. **Recovery Behavior**: When connection is lost, the integration attempts auto-recovery with exponential backoff (10s → 300s max) for up to 10 attempts. After max attempts, manual intervention is required.

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
   "quality_scale": "platinum",
   "requirements": [
-    "aiohttp>=3.10.0",
+    "aiohttp>=3.11.0",
     "violet-poolController-api==0.0.3"
   ],
   "version": "1.0.4-beta.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 # Development tools
 # Tested against Home Assistant 2026.3 (Python 3.14)
-ruff>=0.9.0
-mypy>=1.13.0
-pytest>=8.0.0
-pytest-cov>=5.0.0
-pytest-asyncio>=0.23.0
+ruff>=0.15.0
+mypy>=1.15.0
+pytest>=9.0.0
+pytest-cov>=6.0.0
+pytest-asyncio>=1.0.0
 # IMPORTANT: Always use latest version from https://github.com/MatthewFlamm/pytest-homeassistant-custom-component
 # Check for updates when new HA or Python versions are released
-pytest-homeassistant-custom-component>=0.13.317
+pytest-homeassistant-custom-component>=0.13.109

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirements.txt
 # Tested against Home Assistant 2026.3 (Python 3.14)
-homeassistant>=2025.12.0
-aiohttp>=3.10.0
-voluptuous>=0.14.2
+homeassistant>=2026.3.0
+aiohttp>=3.11.0
+voluptuous>=0.15.0


### PR DESCRIPTION
- homeassistant>=2026.3.0, aiohttp>=3.11.0, voluptuous>=0.15.0
- ruff>=0.15.0, mypy>=1.15.0, pytest>=9.0.0, pytest-cov>=6.0.0
- pytest-asyncio>=1.0.0 (major version bump)
- Fix pytest-homeassistant-custom-component: 0.13.317→0.13.109 (invalid version)
- Fix GitHub Actions: checkout@v6→v4, setup-python@v6→v5
- Fix pip install quoting for >= constraints in validate.yml
- Update HA test matrix to 2026.3.1 / Python 3.14

https://claude.ai/code/session_01EgPxFL9XuzWTGfmzyzLSHL

## Summary by Sourcery

Update runtime, development, and CI dependencies for compatibility with Home Assistant 2026.3 and Python 3.14.

Enhancements:
- Raise minimum Home Assistant, aiohttp, and voluptuous versions for the integration and manifest requirements.

Build:
- Bump development tooling versions for ruff, mypy, pytest, pytest-cov, pytest-asyncio, and pytest-homeassistant-custom-component.

CI:
- Update GitHub Actions workflow to use supported checkout/setup-python action versions, correct pip constraint quoting, and adjust the HA/Python test matrix to 2026.3.1 / 3.14.

Documentation:
- Refresh contributor documentation to reflect new minimum Home Assistant version, updated dependency versions, and CI test environments.