### PR TITLE
Fix test linter errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import threading
-from unittest.mock import patch, MagicMock
 
 # CRITICAL: Patch deprecated timezone BEFORE any imports
 # pytest-homeassistant-custom-component uses 'US/Pacific' which is deprecated

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -2,9 +2,6 @@
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.violet_pool_controller import (
-    async_setup_entry,
-)
 from custom_components.violet_pool_controller.const import (
     CONF_ACTIVE_FEATURES,
     CONF_API_URL,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,5 +1,4 @@
 """Tests for Violet Pool Controller Device."""
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_diagnostic_services.py
+++ b/tests/test_diagnostic_services.py
@@ -1,7 +1,6 @@
 """Tests for diagnostic services."""
 import pytest
-from unittest.mock import Mock, AsyncMock, patch
-from datetime import datetime
+from unittest.mock import Mock, AsyncMock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from homeassistant import config_entries
 from homeassistant.components.zeroconf import AsyncServiceInfo
 from homeassistant.core import HomeAssistant
 

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,7 +1,6 @@
 """Tests for enhanced error handler."""
 import pytest
 import asyncio
-from unittest.mock import Mock, patch
 
 from custom_components.violet_pool_controller.error_handler import (
     ErrorType,

--- a/tests/test_offline_scenarios.py
+++ b/tests/test_offline_scenarios.py
@@ -2,7 +2,6 @@
 import pytest
 import asyncio
 from unittest.mock import Mock, AsyncMock, patch
-from datetime import datetime
 
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -311,7 +310,6 @@ class TestOfflineErrorHandling:
         """Test that errors are properly classified."""
         from custom_components.violet_pool_controller.error_handler import (
             get_enhanced_error_handler,
-            ErrorType,
         )
 
         handler = get_enhanced_error_handler()

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -1,6 +1,6 @@
 """Tests for platform error handling."""
 import pytest
-from unittest.mock import Mock, AsyncMock, MagicMock
+from unittest.mock import Mock
 
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.components.number import NumberEntityDescription
@@ -223,8 +223,7 @@ class TestNumberErrorHandling:
         number = VioletNumber(mock_coordinator_error, config_entry, desc, _setpoint_config)
 
         # Should handle gracefully
-        value = number.native_value
-        # May be None or 0 depending on implementation
+        assert number.native_value is None or isinstance(number.native_value, (int, float))
 
 
 class TestSelectErrorHandling:
@@ -268,8 +267,7 @@ class TestSelectErrorHandling:
         )
 
         # Should handle gracefully
-        current = select.current_option
-        # May show invalid value or fallback
+        assert select.current_option is None or select.current_option in select.options
 
 
 class TestCoordinatorErrors:

--- a/tests/test_reconfigure_flow.py
+++ b/tests/test_reconfigure_flow.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-import voluptuous as vol
 
 
 from custom_components.violet_pool_controller.const import CONF_API_URL, CONF_USERNAME, CONF_PASSWORD, CONF_USE_SSL
@@ -105,7 +103,6 @@ class TestReconfigureFlow:
             # Verify entry was updated
             hass.config_entries.async_update_entry.assert_called_once()
             call_args = hass.config_entries.async_update_entry.call_args
-            updated_entry = call_args[0][0]
             updated_data = call_args[1]["data"]
 
             # Verify new values
@@ -319,7 +316,7 @@ class TestReconfigureFlow:
                 "retry_attempts": 3,
             }
 
-            result_http = await config_flow.async_step_reconfigure(
+            await config_flow.async_step_reconfigure(
                 user_input=user_input_http
             )
 
@@ -338,7 +335,7 @@ class TestReconfigureFlow:
                 "retry_attempts": 3,
             }
 
-            result_https = await config_flow.async_step_reconfigure(
+            await config_flow.async_step_reconfigure(
                 user_input=user_input_https
             )
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -486,9 +486,6 @@ class TestBilingualSupport:
 
     def test_disclaimer_bilingual(self, strings_data):
         """Test that disclaimer is bilingual."""
-        disclaimer_step = strings_data["config"]["step"].get("disclaimer", {})
-        description = disclaimer_step.get("description", "")
-
         # Test removed because translation file format and text has changed to standard i18n placeholders.
         pass
 

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -1,6 +1,5 @@
 """Tests for type hints and mypy compliance."""
 import pytest
-from custom_components.violet_pool_controller.climate import VioletClimateEntity
 from custom_components.violet_pool_controller.cover import VioletCover
 from violet_poolcontroller_api.const_devices import COVER_STATE_MAP
 
@@ -23,7 +22,6 @@ class TestTypeHints:
     @pytest.mark.asyncio
     async def test_cover_properties_return_bool(self):
         """Test that cover properties return boolean values."""
-        from unittest.mock import MagicMock
         from pytest_homeassistant_custom_component.common import MockConfigEntry
 
         # Mock coordinator


### PR DESCRIPTION
Cleaned up unused imports and variables in test suite flagged by Ruff. Updated assertions in test_platform_errors.py to accurately validate values.

---
*PR created automatically by Jules for task [17520029725774747380](https://jules.google.com/task/17520029725774747380) started by @Xerolux*

## Summary by Sourcery

Clean up test suite to resolve linter warnings and tighten value assertions in error-handling tests.

Bug Fixes:
- Adjust platform error tests to assert valid native values and options instead of ignoring them.

Tests:
- Remove unused variables, imports, and dead test code flagged by the linter across multiple test modules.