### PR TITLE
Auto-detect controller type (dosing_standalone) during setup

### DIFF
--- a/custom_components/violet_pool_controller/strings.json
+++ b/custom_components/violet_pool_controller/strings.json
@@ -35,8 +35,7 @@
                     "device_id": "Geräte-ID",
                     "polling_interval": "Abrufintervall (Sekunden)",
                     "timeout_duration": "Timeout (Sekunden)",
-                    "retry_attempts": "Wiederholungsversuche",
-                    "dosing_standalone": "Standalone Dosierung"
+                    "retry_attempts": "Wiederholungsversuche"
                 },
                 "data_description": {
                     "host": "DE: IP oder DNS-Name des Controllers · EN: Controller IP or DNS name",
@@ -48,8 +47,7 @@
                     "device_id": "DE: Eindeutige ID bei mehreren Controllern · EN: Unique ID if multiple controllers exist",
                     "polling_interval": "DE: Intervall für Datenabrufe (10-3600s) · EN: Data polling interval (10-3600s)",
                     "timeout_duration": "DE: Maximale Wartezeit pro Anfrage · EN: Maximum wait time per request",
-                    "retry_attempts": "DE: Anzahl Wiederholungsversuche · EN: Number of retry attempts",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "DE: Anzahl Wiederholungsversuche · EN: Number of retry attempts"
                 }
             },
             "pool_setup": {
@@ -179,8 +177,7 @@
                     "timeout_duration": "Timeout (Sekunden)",
                     "retry_attempts": "Wiederholungsversuche",
                     "enable_diagnostic_logging": "Erweiterte Protokollierung",
-                    "force_update": "Immer aktualisieren",
-                    "dosing_standalone": "Standalone Dosierung"
+                    "force_update": "Immer aktualisieren"
                 },
                 "data_description": {
                     "controller_name": "DE: Anzeigename des Controllers · EN: Controller display name",
@@ -188,8 +185,7 @@
                     "timeout_duration": "DE: Maximale Wartezeit pro Anfrage (5-60s) · EN: Maximum wait time per request (5-60s)",
                     "retry_attempts": "DE: Anzahl Wiederholungsversuche bei Fehlern (1-10) · EN: Number of retry attempts on failure (1-10)",
                     "enable_diagnostic_logging": "DE: Ausführliche Logs bei jedem Update (nur für Diagnose!) · EN: Verbose logs on every update (diagnostics only!)",
-                    "force_update": "DE: Entities immer aktualisieren, auch wenn Wert gleich · EN: Always update entities even if value unchanged",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "force_update": "DE: Entities immer aktualisieren, auch wenn Wert gleich · EN: Always update entities even if value unchanged"
                 }
             }
         }

--- a/custom_components/violet_pool_controller/translations/de.json
+++ b/custom_components/violet_pool_controller/translations/de.json
@@ -36,8 +36,7 @@
                     "device_id": "Geräte-ID",
                     "polling_interval": "Abrufintervall (Sekunden)",
                     "timeout_duration": "Timeout (Sekunden)",
-                    "retry_attempts": "Wiederholungsversuche",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Wiederholungsversuche"
                 },
                 "data_description": {
                     "host": "IP oder DNS-Name des Controllers",
@@ -50,8 +49,7 @@
                     "device_id": "Eindeutige ID bei mehreren Controllern",
                     "polling_interval": "Intervall für Datenabrufe (10-3600s)",
                     "timeout_duration": "Maximale Wartezeit pro Anfrage",
-                    "retry_attempts": "Anzahl Wiederholungsversuche",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Anzahl Wiederholungsversuche"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Allgemeine Einstellungen",
                 "description": "Passe die technischen Parameter an\n\nPolling-Intervall: Wie oft Daten abgerufen werden\nTimeout: Maximale Wartezeit für Antworten\nWiederholungen: Anzahl Retry-Versuche\n\nStandard-Werte funktionieren für die meisten Setups!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/en.json
+++ b/custom_components/violet_pool_controller/translations/en.json
@@ -36,8 +36,7 @@
                     "device_id": "Device ID",
                     "polling_interval": "Polling Interval (seconds)",
                     "timeout_duration": "Timeout (seconds)",
-                    "retry_attempts": "Retry Attempts",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Retry Attempts"
                 },
                 "data_description": {
                     "host": "Controller IP or DNS name",
@@ -50,8 +49,7 @@
                     "device_id": "Unique ID if multiple controllers exist",
                     "polling_interval": "Data polling interval (10-3600s)",
                     "timeout_duration": "Maximum wait time per request",
-                    "retry_attempts": "Number of retry attempts",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Number of retry attempts"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "General Settings",
                 "description": "Adjust the technical parameters\n\nPolling Interval: How often data is fetched\nTimeout: Maximum wait time for responses\nRetries: Number of retry attempts\n\nDefault values work for most setups!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/es.json
+++ b/custom_components/violet_pool_controller/translations/es.json
@@ -36,8 +36,7 @@
                     "device_id": "ID del dispositivo",
                     "polling_interval": "Intervalo de sondeo (segundos)",
                     "timeout_duration": "Tiempo de espera (segundos)",
-                    "retry_attempts": "Reintentar intentos",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Reintentar intentos"
                 },
                 "data_description": {
                     "host": "IP del controlador o nombre DNS",
@@ -50,8 +49,7 @@
                     "device_id": "ID único si existen varios controladores",
                     "polling_interval": "Intervalo de sondeo de datos (10-3600 s)",
                     "timeout_duration": "Tiempo máximo de espera por solicitud",
-                    "retry_attempts": "Número de reintentos",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Número de reintentos"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Configuraciones generales",
                 "description": "Ajustar los parámetros técnicos.\n\nIntervalo de sondeo: con qué frecuencia se obtienen los datos\nTimeout: tiempo máximo de espera para respuestas\nReintentos: número de reintentos\n\n¡Los valores predeterminados funcionan para la mayoría de las configuraciones!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/fr.json
+++ b/custom_components/violet_pool_controller/translations/fr.json
@@ -36,8 +36,7 @@
                     "device_id": "ID de l'appareil",
                     "polling_interval": "Intervalle d'interrogation (secondes)",
                     "timeout_duration": "Délai d'expiration (secondes)",
-                    "retry_attempts": "Nouvelles tentatives",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Nouvelles tentatives"
                 },
                 "data_description": {
                     "host": "IP du contrôleur ou nom DNS",
@@ -50,8 +49,7 @@
                     "device_id": "ID unique s'il existe plusieurs contrôleurs",
                     "polling_interval": "Intervalle d'interrogation des données (10 à 3 600 s)",
                     "timeout_duration": "Temps d'attente maximum par demande",
-                    "retry_attempts": "Nombre de nouvelles tentatives",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Nombre de nouvelles tentatives"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Paramètres généraux",
                 "description": "Ajuster les paramètres techniques\n\nIntervalle d'interrogation : à quelle fréquence les données sont récupérées\nTimeout : temps d'attente maximum pour les réponses\nNouvelles tentatives : nombre de nouvelles tentatives\n\nLes valeurs par défaut fonctionnent pour la plupart des configurations !",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/it.json
+++ b/custom_components/violet_pool_controller/translations/it.json
@@ -36,8 +36,7 @@
                     "device_id": "ID del dispositivo",
                     "polling_interval": "Intervallo di polling (secondi)",
                     "timeout_duration": "Timeout (secondi)",
-                    "retry_attempts": "Riprovare i tentativi",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Riprovare i tentativi"
                 },
                 "data_description": {
                     "host": "Nome IP o DNS del controller",
@@ -50,8 +49,7 @@
                     "device_id": "ID univoco se esistono più controller",
                     "polling_interval": "Intervallo di polling dei dati (10-3600 s)",
                     "timeout_duration": "Tempo massimo di attesa per richiesta",
-                    "retry_attempts": "Numero di tentativi",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Numero di tentativi"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Impostazioni generali",
                 "description": "Regolare i parametri tecnici\n\nIntervallo di polling: la frequenza con cui vengono recuperati i dati\nTimeout: tempo massimo di attesa per le risposte\nTentativi: numero di tentativi\n\nI valori predefiniti funzionano per la maggior parte delle configurazioni!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/nl.json
+++ b/custom_components/violet_pool_controller/translations/nl.json
@@ -36,8 +36,7 @@
                     "device_id": "Apparaat-ID",
                     "polling_interval": "Polling-interval (seconden)",
                     "timeout_duration": "Time-out (seconden)",
-                    "retry_attempts": "Probeer pogingen opnieuw",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Probeer pogingen opnieuw"
                 },
                 "data_description": {
                     "host": "IP- of DNS-naam van controller",
@@ -50,8 +49,7 @@
                     "device_id": "Unieke ID als er meerdere controllers bestaan",
                     "polling_interval": "Interval voor gegevensopvragen (10-3600s)",
                     "timeout_duration": "Maximale wachttijd per aanvraag",
-                    "retry_attempts": "Aantal nieuwe pogingen",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Aantal nieuwe pogingen"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Algemene instellingen",
                 "description": "Pas de technische parameters aan\n\nPollinginterval: hoe vaak gegevens worden opgehaald\nTime-out: maximale wachttijd voor reacties\nNieuwe pogingen: aantal nieuwe pogingen\n\nStandaardwaarden werken voor de meeste instellingen!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/pl.json
+++ b/custom_components/violet_pool_controller/translations/pl.json
@@ -36,8 +36,7 @@
                     "device_id": "Identyfikator urządzenia",
                     "polling_interval": "Interwał odpytywania (sekundy)",
                     "timeout_duration": "Limit czasu (sekundy)",
-                    "retry_attempts": "Ponów próby",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Ponów próby"
                 },
                 "data_description": {
                     "host": "IP kontrolera lub nazwa DNS",
@@ -50,8 +49,7 @@
                     "device_id": "Unikalny identyfikator, jeśli istnieje wiele kontrolerów",
                     "polling_interval": "Interwał odpytywania danych (10–3600 s)",
                     "timeout_duration": "Maksymalny czas oczekiwania na żądanie",
-                    "retry_attempts": "Liczba ponownych prób",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Liczba ponownych prób"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Ustawienia ogólne",
                 "description": "Dostosuj parametry techniczne\n\nInterwał sondowania: częstotliwość pobierania danych\nLimit czasu: Maksymalny czas oczekiwania na odpowiedzi\nPonawianie prób: liczba ponownych prób\n\nWartości domyślne działają w przypadku większości konfiguracji!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/pt.json
+++ b/custom_components/violet_pool_controller/translations/pt.json
@@ -36,8 +36,7 @@
                     "device_id": "ID do dispositivo",
                     "polling_interval": "Intervalo de pesquisa (segundos)",
                     "timeout_duration": "Tempo limite (segundos)",
-                    "retry_attempts": "Novas tentativas",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Novas tentativas"
                 },
                 "data_description": {
                     "host": "IP do controlador ou nome DNS",
@@ -50,8 +49,7 @@
                     "device_id": "ID exclusivo se existirem vários controladores",
                     "polling_interval": "Intervalo de pesquisa de dados (10-3600s)",
                     "timeout_duration": "Tempo máximo de espera por solicitação",
-                    "retry_attempts": "Número de novas tentativas",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Número de novas tentativas"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Configurações Gerais",
                 "description": "Ajuste os parâmetros técnicos\n\nIntervalo de pesquisa: com que frequência os dados são buscados\nTimeout: Tempo máximo de espera por respostas\nNovas tentativas: Número de novas tentativas\n\nOs valores padrão funcionam para a maioria das configurações!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/ru.json
+++ b/custom_components/violet_pool_controller/translations/ru.json
@@ -36,8 +36,7 @@
                     "device_id": "Идентификатор устройства",
                     "polling_interval": "Интервал опроса (секунды)",
                     "timeout_duration": "Тайм-аут (секунды)",
-                    "retry_attempts": "Повторить попытки",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "Повторить попытки"
                 },
                 "data_description": {
                     "host": "IP-адрес или DNS-имя контроллера",
@@ -50,8 +49,7 @@
                     "device_id": "Уникальный идентификатор, если существует несколько контроллеров",
                     "polling_interval": "Интервал опроса данных (10-3600 с)",
                     "timeout_duration": "Максимальное время ожидания одного запроса",
-                    "retry_attempts": "Количество повторных попыток",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "Количество повторных попыток"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "Общие настройки",
                 "description": "Отрегулируйте технические параметры\n\nИнтервал опроса: как часто извлекаются данные\nТаймаут: максимальное время ожидания ответов.\nПовторы: количество повторных попыток.\n\nЗначения по умолчанию подходят для большинства настроек!",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },

--- a/custom_components/violet_pool_controller/translations/zh.json
+++ b/custom_components/violet_pool_controller/translations/zh.json
@@ -36,8 +36,7 @@
                     "device_id": "设备ID",
                     "polling_interval": "轮询间隔（秒）",
                     "timeout_duration": "超时（秒）",
-                    "retry_attempts": "重试尝试",
-                    "dosing_standalone": "Standalone Dosing"
+                    "retry_attempts": "重试尝试"
                 },
                 "data_description": {
                     "host": "控制器 IP 或 DNS 名称",
@@ -50,8 +49,7 @@
                     "device_id": "如果存在多个控制器，则唯一 ID",
                     "polling_interval": "数据轮询间隔（10-3600s）",
                     "timeout_duration": "每个请求的最长等待时间",
-                    "retry_attempts": "重试次数",
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
+                    "retry_attempts": "重试次数"
                 }
             },
             "pool_setup": {
@@ -195,12 +193,8 @@
             "settings": {
                 "title": "常规设置",
                 "description": "调整技术参数\n\n轮询间隔：获取数据的频率\n超时：响应的最大等待时间\n重试次数：重试次数\n\n默认值适用于大多数设置！",
-                "data": {
-                    "dosing_standalone": "Standalone Dosing"
-                },
-                "data_description": {
-                    "dosing_standalone": "DE: Violet Pool Controller steuert nur Dosierung · EN: Violet Pool Controller controls dosing only"
-                }
+                "data": {},
+                "data_description": {}
             }
         }
     },


### PR DESCRIPTION
This commit automates the detection of the controller type (whether it is a Standalone Dosing controller) by extracting the value directly from the `api.dosing_standalone` property after `_test_connection` succeeds. The corresponding manual UI steps have been removed from the setup, options, and reconfiguration flows, along with their translation strings.

---
*PR created automatically by Jules for task [5543326801031558321](https://jules.google.com/task/5543326801031558321) started by @Xerolux*

## Summary by Sourcery

Auto-detect the controller type from the API after connection and remove related manual configuration steps.

New Features:
- Determine whether the controller is dosing standalone automatically from the API once connection testing succeeds.

Enhancements:
- Simplify setup, options, and reconfiguration flows by removing the manual controller-type selection step.

Documentation:
- Update user-facing translations and strings to reflect the removal of the manual controller-type selection UI.