### PR TITLE
Refactor dosing standalone UI and update device model strings

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -387,9 +387,6 @@ class ConfigFlow(
             CONF_RETRY_ATTEMPTS: DEFAULT_RETRY_ATTEMPTS,
         }
 
-        from .const import CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
-        self._config_data[CONF_DOSING_STANDALONE] = DEFAULT_DOSING_STANDALONE
-
         self._title_placeholders = {
             "name": name,
             "host": f"{host}:{port}" if port not in (80, 443) else host,
@@ -457,10 +454,6 @@ class ConfigFlow(
                 )
                 updated_data[CONF_RETRY_ATTEMPTS] = int(
                     user_input.get(CONF_RETRY_ATTEMPTS, DEFAULT_RETRY_ATTEMPTS)
-                )
-                from .const import CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
-                updated_data[CONF_DOSING_STANDALONE] = user_input.get(
-                    CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
                 )
 
                 self._config_data = updated_data
@@ -548,12 +541,6 @@ class ConfigFlow(
                             mode=selector.NumberSelectorMode.BOX,
                         )
                     ),
-                    vol.Optional(
-                        "dosing_standalone",
-                        default=reconfigure_entry.data.get(
-                            "dosing_standalone", False
-                        ),
-                    ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 }
             ),
             errors=errors,
@@ -594,8 +581,6 @@ class ConfigFlow(
                 ui.get(CONF_RETRY_ATTEMPTS, DEFAULT_RETRY_ATTEMPTS)
             ),
         }
-        from .const import CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
-        config_data[CONF_DOSING_STANDALONE] = ui.get(CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE)
         return config_data
 
     async def _test_connection(self) -> bool:
@@ -605,7 +590,6 @@ class ConfigFlow(
             port = self._config_data.get(CONF_PORT, DEFAULT_PORT)
             if port not in (80, 443):
                 host = f"{host}:{port}"
-            from .const import CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
             api = VioletPoolAPI(
                 host=host,
                 session=aiohttp_client.async_get_clientsession(self.hass),
@@ -615,7 +599,6 @@ class ConfigFlow(
                 verify_ssl=self._config_data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
                 timeout=self._config_data[CONF_TIMEOUT_DURATION],
                 max_retries=self._config_data[CONF_RETRY_ATTEMPTS],
-                dosing_standalone=self._config_data.get(CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE),
             )
             await api.get_readings()
             return True

--- a/custom_components/violet_pool_controller/config_flow_support.py
+++ b/custom_components/violet_pool_controller/config_flow_support.py
@@ -18,7 +18,6 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_DEVICE_NAME,
     CONF_DISINFECTION_METHOD,
-    CONF_DOSING_STANDALONE,
     CONF_ENABLE_DIAGNOSTIC_LOGGING,
     CONF_FORCE_UPDATE,
     CONF_PASSWORD,
@@ -33,7 +32,6 @@ from .const import (
     CONF_USERNAME,
     DEFAULT_CONTROLLER_NAME,
     DEFAULT_DISINFECTION_METHOD,
-    DEFAULT_DOSING_STANDALONE,
     DEFAULT_ENABLE_DIAGNOSTIC_LOGGING,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_POLLING_INTERVAL,
@@ -477,12 +475,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_FORCE_UPDATE,
                     default=self.current_config.get(
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
-                    ),
-                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
-                vol.Optional(
-                    CONF_DOSING_STANDALONE,
-                    default=self.current_config.get(
-                        CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -609,12 +609,24 @@ class VioletPoolControllerDevice:
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information for Home Assistant."""
+        model_parts = ["Violet Pool Controller"]
+        if self._data.get("HW_BASE_MODULE"):
+            model_parts.append("Base")
+        if self._data.get("HW_DOSING_MODULE"):
+            model_parts.append("Dosing")
+        if self._data.get("HW_EXTENSION_MODULE_1"):
+            model_parts.append("Ext1")
+        if self._data.get("HW_EXTENSION_MODULE_2"):
+            model_parts.append("Ext2")
+
+        model_str = " + ".join(model_parts) if len(model_parts) > 1 else "Violet Pool Controller"
+
         return {
             "identifiers": {(DOMAIN, f"{self.api_url}_{self.device_id}")},
             # Uses controller_name for visual distinction in multi-controller setups
             "name": self.controller_name,
             "manufacturer": "PoolDigital GmbH & Co. KG",
-            "model": "Violet Pool Controller",
+            "model": model_str,
             "sw_version": self._firmware_version or "Unknown",
             "suggested_area": self.controller_name,  # ✅ Auto-Area für Multi-Controller
         }


### PR DESCRIPTION
Removed the manual `dosing_standalone` setting from the configuration flow schemas since this feature is already handled by automatic detection. Additionally, modified the Home Assistant device registry implementation to append any dynamically detected hardware modules (such as Base, Dosing, Ext1, and Ext2) to the device's model string. This dynamically updates the Device Information card in Home Assistant without needing multiple distinct device entities.

---
*PR created automatically by Jules for task [469750191520673633](https://jules.google.com/task/469750191520673633) started by @Xerolux*

## Summary by Sourcery

Refine Violet Pool Controller configuration and device representation in Home Assistant.

Enhancements:
- Remove the manual dosing standalone configuration option in favor of automatic detection in the config flow.
- Augment Home Assistant device model strings with dynamically detected hardware modules (Base, Dosing, Ext1, Ext2) for clearer device identification.