### PR TITLE
fix: correct detection of missing hardware modules (e.g. Ext2) in Violet device_info

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -572,17 +572,20 @@ class VioletPoolControllerDevice:
         data = await self.api.get_readings()
 
         if isinstance(data, dict):
+            def is_valid(val: Any) -> bool:
+                return val is not None and str(val).strip().upper() != "N/A"
+
             # Derive hardware presence from the filtered data returned by the API.
             # For dosing: check the CPU-temperature key *and* any DOS_* key so
             # that detection works even when the temperature sensor is absent.
             has_dosing = (
                 self.api.dosing_standalone
-                or data.get("SYSTEM_dosagemodule_cpu_temperature") not in (None, "N/A", "n/a")
-                or any(k.startswith("DOS_") for k in data)
+                or is_valid(data.get("SYSTEM_dosagemodule_cpu_temperature"))
+                or any(k.startswith("DOS_") and is_valid(v) for k, v in data.items())
             )
-            # For extension modules: any EXT1_* / EXT2_* key signals presence.
-            has_ext1 = any(k.startswith("EXT1_") for k in data)
-            has_ext2 = any(k.startswith("EXT2_") for k in data)
+            # For extension modules: any valid EXT1_* / EXT2_* key signals presence.
+            has_ext1 = any(k.startswith("EXT1_") and is_valid(v) for k, v in data.items())
+            has_ext2 = any(k.startswith("EXT2_") and is_valid(v) for k, v in data.items())
 
             is_standalone = self.api.dosing_standalone
 


### PR DESCRIPTION
This PR fixes an issue where the Violet Pool Controller was incorrectly reporting the Ext2 (Hardware Extension Module 2) as present when it was not physically installed.

**Root Cause:**
The underlying Violet Pool Controller API returns keys starting with `EXT2_` even when the extension board is missing, but gives them the value `'N/A'` or `'n/a'`. The integration previously determined hardware presence by simply checking if *any* key starting with `EXT2_` existed in the dictionary (`any(k.startswith("EXT2_") for k in data)`).

**Fix:**
Introduced an `is_valid` utility in `device.py` that verifies the value is not `None` and not `"N/A"`. It now applies this check properly to the Dosing module, the Ext1 module, and the Ext2 module. This guarantees a module is only flagged as present if it provides actual metric data.

**Verification:**
The test suite ran perfectly with all 215 tests succeeding.

---
*PR created automatically by Jules for task [2795309522933943772](https://jules.google.com/task/2795309522933943772) started by @Xerolux*

## Summary by Sourcery

Ensure Violet pool controller only reports dosing and extension hardware modules as present when they expose valid metric data.

Bug Fixes:
- Correct detection of dosing and extension (Ext1/Ext2) modules so that modules with only placeholder or N/A readings are no longer treated as installed.

Enhancements:
- Introduce a shared validity check helper to consistently filter out placeholder N/A values from hardware presence detection logic.