### PR TITLE
fix: EXT1/EXT2 sticky hardware detection + longer refresh delay

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -97,6 +97,14 @@ class VioletPoolControllerDevice:
         self._connection_latency = 0.0  # Last connection latency in milliseconds
         self._system_health = 100.0  # System health percentage (0-100)
 
+        # Sticky hardware module detection: once a module is detected it is never
+        # de-detected within the same HA session.  The API package (0.0.12+) filters
+        # EXT1/EXT2 keys when the module looks absent (e.g. LAST_ON == 0 for a
+        # freshly connected, never-used relay board).  Without this cache those keys
+        # would disappear from coordinator.data and switch entities would silently
+        # revert to OFF even though the relay board is physically present.
+        self._hw_detected: set[str] = set()
+
         # ✅ DIAGNOSTIC SENSORS: Advanced metrics
         self._api_request_count = 0  # Total API requests
         self._api_request_start_time = time.monotonic()  # For rate calculation
@@ -575,6 +583,16 @@ class VioletPoolControllerDevice:
             def is_valid(val: Any) -> bool:
                 return val is not None and str(val).strip().upper() != "N/A"
 
+            def is_alive_count(key: str) -> bool:
+                """Return True when the controller reports a positive alive count."""
+                val = data.get(key)
+                if val is None:
+                    return False
+                try:
+                    return float(str(val).strip()) > 0
+                except (ValueError, TypeError):
+                    return False
+
             # Derive hardware presence from the filtered data returned by the API.
             # For dosing: check the CPU-temperature key *and* any DOS_* key so
             # that detection works even when the temperature sensor is absent.
@@ -583,9 +601,40 @@ class VioletPoolControllerDevice:
                 or is_valid(data.get("SYSTEM_dosagemodule_cpu_temperature"))
                 or any(k.startswith("DOS_") and is_valid(v) for k, v in data.items())
             )
-            # For extension modules: any valid EXT1_* / EXT2_* key signals presence.
-            has_ext1 = any(k.startswith("EXT1_") and is_valid(v) for k, v in data.items())
-            has_ext2 = any(k.startswith("EXT2_") and is_valid(v) for k, v in data.items())
+
+            # For extension modules use a two-tier approach:
+            # 1. SYSTEM_ext*module_alive_count: reliable when the controller sends it.
+            # 2. Any EXT1_/EXT2_ key present in the (already-filtered) data.
+            # Sticky cache: once detected in a session, always considered present.
+            # This covers fresh relay boards (LAST_ON == 0, alive count absent) whose
+            # keys are otherwise filtered out by the API package.
+            has_ext1_now = (
+                is_alive_count("SYSTEM_ext1module_alive_count")
+                or any(k.startswith("EXT1_") and is_valid(v) for k, v in data.items())
+            )
+            has_ext2_now = (
+                is_alive_count("SYSTEM_ext2module_alive_count")
+                or any(k.startswith("EXT2_") and is_valid(v) for k, v in data.items())
+            )
+            if has_ext1_now:
+                self._hw_detected.add("EXT1")
+            if has_ext2_now:
+                self._hw_detected.add("EXT2")
+
+            has_ext1 = "EXT1" in self._hw_detected
+            has_ext2 = "EXT2" in self._hw_detected
+
+            # When the API package has filtered EXT keys out (module not yet detected
+            # via LAST_ON) but we know from a previous poll that the module IS present,
+            # restore the last known state values so switch entities remain consistent.
+            if has_ext1 and not has_ext1_now:
+                for prev_key, prev_val in self._data.items():
+                    if prev_key.startswith("EXT1_") and prev_key not in data:
+                        data[prev_key] = prev_val
+            if has_ext2 and not has_ext2_now:
+                for prev_key, prev_val in self._data.items():
+                    if prev_key.startswith("EXT2_") and prev_key not in data:
+                        data[prev_key] = prev_val
 
             is_standalone = self.api.dosing_standalone
 

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -15,7 +15,7 @@
   "quality_scale": "platinum",
   "requirements": [
     "aiohttp>=3.11.0",
-    "violet-poolController-api==0.0.12"
+    "violet-poolController-api==0.0.13"
   ],
   "version": "1.0.5",
   "zeroconf": [

--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -53,6 +53,9 @@ ON_STATES = {1, 2, 3, 4}
 OFF_STATES = {0, 5, 6}
 
 REFRESH_DELAY = 0.3
+# Extension module relays may need more time for the controller to update LAST_ON
+# after a command, so that the next get_readings() call can detect the module.
+REFRESH_DELAY_EXT = 1.5
 
 
 class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
@@ -480,8 +483,12 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
             key: The switch key.
         """
         try:
+            # EXT switches need a longer delay so the controller can update
+            # EXT*_LAST_ON before the next get_readings() call, which is required
+            # for the API package's hardware detection to recognise the module.
+            delay = REFRESH_DELAY_EXT if key.startswith("EXT") else REFRESH_DELAY
             success = await self._request_coordinator_refresh(
-                delay=REFRESH_DELAY, log_context=key
+                delay=delay, log_context=key
             )
 
             if success and self.coordinator.data is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 homeassistant>=2026.3.0
 aiohttp>=3.11.0
 voluptuous>=0.15.0
-violet-poolController-api==0.0.11
+violet-poolController-api==0.0.13

--- a/tests/test_ext1_switching.py
+++ b/tests/test_ext1_switching.py
@@ -1,0 +1,215 @@
+"""Tests for EXT1/EXT2 switch detection and command handling.
+
+Regression tests for the bug introduced with API 0.0.12:
+- The API package filters EXT1_* keys when the module is not "detected"
+  (LAST_ON == 0 for all relays and SYSTEM_ext1module_alive_count is absent).
+- The integration must use sticky detection so the module is never lost once
+  it has been found, and must restore previous EXT state values into
+  coordinator.data when the API filter removes them.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.violet_pool_controller.const import (
+    CONF_API_URL,
+    CONF_CONTROLLER_NAME,
+    CONF_DEVICE_ID,
+    CONF_DEVICE_NAME,
+    CONF_USE_SSL,
+    DOMAIN,
+)
+from custom_components.violet_pool_controller.device import VioletPoolControllerDevice
+from custom_components.violet_pool_controller.switch import (
+    REFRESH_DELAY,
+    REFRESH_DELAY_EXT,
+)
+from violet_poolcontroller_api.const_devices import DEVICE_PARAMETERS
+
+
+@pytest.fixture
+def config_entry():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Pool",
+        data={
+            CONF_API_URL: "192.168.178.55",
+            CONF_USE_SSL: False,
+            CONF_DEVICE_ID: 1,
+            CONF_DEVICE_NAME: "Test Pool Controller",
+            CONF_CONTROLLER_NAME: "Test Pool",
+        },
+    )
+
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock()
+    api.dosing_standalone = False
+    return api
+
+
+@pytest.fixture
+def device(hass, config_entry, mock_api):
+    with patch(
+        "custom_components.violet_pool_controller.device.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        return VioletPoolControllerDevice(
+            hass=hass,
+            config_entry=config_entry,
+            api=mock_api,
+        )
+
+
+# ===========================================================================
+# Hardware detection
+# ===========================================================================
+
+
+class TestExt1HardwareDetection:
+    """EXT1/EXT2 hardware detection in _fetch_controller_data."""
+
+    async def test_ext1_detected_via_alive_count(self, device, mock_api):
+        """SYSTEM_ext1module_alive_count > 0 signals EXT1 presence."""
+        mock_api.get_readings = AsyncMock(
+            return_value={
+                "PUMP": 1,
+                "SYSTEM_ext1module_alive_count": 5,
+            }
+        )
+        data = await device._fetch_controller_data()
+        assert data["HW_EXTENSION_MODULE_1"] is True
+        assert "EXT1" in device._hw_detected
+
+    async def test_ext1_detected_via_data_keys(self, device, mock_api):
+        """EXT1_* keys in the (already-filtered) data signal module presence."""
+        mock_api.get_readings = AsyncMock(
+            return_value={"PUMP": 1, "EXT1_1": 4, "EXT1_2": 0}
+        )
+        data = await device._fetch_controller_data()
+        assert data["HW_EXTENSION_MODULE_1"] is True
+        assert "EXT1" in device._hw_detected
+
+    async def test_ext1_not_detected_when_absent(self, device, mock_api):
+        """Module absent: alive count not present, no EXT1 keys."""
+        mock_api.get_readings = AsyncMock(return_value={"PUMP": 1})
+        data = await device._fetch_controller_data()
+        assert data["HW_EXTENSION_MODULE_1"] is False
+        assert "EXT1" not in device._hw_detected
+
+    async def test_ext1_sticky_once_detected(self, device, mock_api):
+        """Once EXT1 detected, it stays True even if keys later disappear."""
+        mock_api.get_readings = AsyncMock(
+            return_value={"PUMP": 1, "EXT1_2": 4, "EXT1_2_LAST_ON": 1_700_000_000}
+        )
+        await device._fetch_controller_data()
+        assert "EXT1" in device._hw_detected
+
+        # Second poll: API filtered all EXT1 keys away
+        mock_api.get_readings = AsyncMock(return_value={"PUMP": 1})
+        data = await device._fetch_controller_data()
+        assert data["HW_EXTENSION_MODULE_1"] is True, (
+            "Sticky detection must keep HW_EXTENSION_MODULE_1 True"
+        )
+
+    async def test_ext1_stale_values_restored_when_filtered(self, device, mock_api):
+        """Previous EXT1 state values are restored when the API filter removes them."""
+        mock_api.get_readings = AsyncMock(
+            return_value={"PUMP": 1, "EXT1_2": 4, "EXT1_2_LAST_ON": 1_700_000_000}
+        )
+        data1 = await device._fetch_controller_data()
+        device._data = data1  # simulate coordinator persisting result
+
+        # Second poll: API removed EXT1 keys (module detection dropped in filter)
+        mock_api.get_readings = AsyncMock(return_value={"PUMP": 0})
+        data2 = await device._fetch_controller_data()
+        assert "EXT1_2" in data2, "EXT1_2 must be restored from previous data"
+        assert data2["EXT1_2"] == 4
+
+    async def test_ext2_sticky_once_detected(self, device, mock_api):
+        """Same sticky logic applies to EXT2."""
+        mock_api.get_readings = AsyncMock(
+            return_value={"PUMP": 1, "EXT2_1": 1, "EXT2_1_LAST_ON": 1_700_000_000}
+        )
+        await device._fetch_controller_data()
+        assert "EXT2" in device._hw_detected
+
+        mock_api.get_readings = AsyncMock(return_value={"PUMP": 1})
+        data = await device._fetch_controller_data()
+        assert data["HW_EXTENSION_MODULE_2"] is True
+
+    def test_hw_detected_initialises_empty(self, device):
+        """_hw_detected is an empty set on device creation."""
+        assert device._hw_detected == set()
+
+
+# ===========================================================================
+# API command format tests (const_devices only – no network needed)
+# ===========================================================================
+
+
+class TestExt1ApiCommandFormat:
+    """API command templates for EXT1/EXT2 relays."""
+
+    def test_ext1_2_command_template(self):
+        """EXT1_2 has the expected comma-separated command template."""
+        tmpl = DEVICE_PARAMETERS.get("EXT1_2", {}).get("api_template", "")
+        assert tmpl == "EXT1_2,{action},{duration},0", (
+            f"Unexpected template: {tmpl!r}"
+        )
+
+    def test_all_ext1_relays_have_templates(self):
+        """All 8 EXT1 relay keys must have an api_template."""
+        for i in range(1, 9):
+            key = f"EXT1_{i}"
+            assert key in DEVICE_PARAMETERS, f"{key} missing from DEVICE_PARAMETERS"
+            assert "api_template" in DEVICE_PARAMETERS[key], (
+                f"{key} missing api_template"
+            )
+
+    def test_ext1_template_action_placeholder(self):
+        """Template contains {action} placeholder for ON/OFF/AUTO."""
+        for i in range(1, 9):
+            tmpl = DEVICE_PARAMETERS[f"EXT1_{i}"]["api_template"]
+            filled = tmpl.format(action="ON", duration=0)
+            assert "ON" in filled
+            filled_off = tmpl.format(action="OFF", duration=0)
+            assert "OFF" in filled_off
+
+    def test_ext1_template_duration_placeholder(self):
+        """Template contains {duration} so timed actions work."""
+        tmpl = DEVICE_PARAMETERS["EXT1_2"]["api_template"]
+        result = tmpl.format(action="ON", duration=300)
+        assert "300" in result, f"Duration not in filled template: {result!r}"
+
+    def test_ext1_template_ends_with_zero(self):
+        """Template always ends with ,0 (no speed/value parameter for relays)."""
+        for i in range(1, 9):
+            tmpl = DEVICE_PARAMETERS[f"EXT1_{i}"]["api_template"]
+            assert tmpl.endswith(",0"), (
+                f"EXT1_{i} template should end with ',0': {tmpl!r}"
+            )
+
+
+# ===========================================================================
+# Refresh delay constants
+# ===========================================================================
+
+
+class TestExt1RefreshDelay:
+    """The switch entity uses a longer delay for EXT keys."""
+
+    def test_ext_delay_longer_than_default(self):
+        """REFRESH_DELAY_EXT must be strictly greater than REFRESH_DELAY."""
+        assert REFRESH_DELAY_EXT > REFRESH_DELAY, (
+            "EXT refresh delay should be longer than default"
+        )
+
+    def test_ext_delay_at_least_one_second(self):
+        """EXT refresh delay should be at least 1 second for controller timing."""
+        assert REFRESH_DELAY_EXT >= 1.0, (
+            "EXT refresh delay should be at least 1 second"
+        )


### PR DESCRIPTION
- device.py: add _hw_detected set for sticky module detection;
  check SYSTEM_ext*module_alive_count; restore stale EXT values
  when API package filters them (fresh relay board, LAST_ON==0)
- switch.py: use REFRESH_DELAY_EXT=1.5s for EXT* keys so the
  controller has time to update LAST_ON before the next poll
- tests: add test_ext1_switching.py with regression coverage

https://claude.ai/code/session_01Rq9oYZgg9wFWwy3oreuP6t

## Summary by Sourcery

Stabilise EXT1/EXT2 hardware detection and switching for extension relay modules.

Bug Fixes:
- Ensure EXT1/EXT2 extension modules remain detected within a Home Assistant session even when the API temporarily omits their keys.
- Prevent EXT1/EXT2 switch entities from reverting to OFF by restoring last known EXT state when API filtering hides module data.
- Avoid premature polling after EXT relay commands by using a longer refresh delay so controller state updates are observed.

Enhancements:
- Introduce sticky hardware presence tracking for extension modules based on alive counters and EXT* keys.

Build:
- Update dependency on violet-poolController-api to version 0.0.13 in integration metadata and requirements.

Tests:
- Add regression tests covering EXT1/EXT2 hardware detection, state restoration, API command templates, and refresh delay behaviour.