### PR TITLE
fix: release workflow tag push and bump to alpha.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,6 +532,10 @@ jobs:
           git push
           echo "✅ Pushed changelog and version updates"
 
+          # Move the tag to the new commit and force push
+          git tag -f "${{ needs.prepare-release.outputs.tag }}"
+          git push -f origin "${{ needs.prepare-release.outputs.tag }}"
+
   post-to-x:
     needs: [prepare-release, update-changelog]
     runs-on: ubuntu-latest

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -39,7 +39,7 @@ from .const_sensors import *
 # =============================================================================
 
 DOMAIN = "violet_pool_controller"
-INTEGRATION_VERSION = "1.0.7-alpha.1"
+INTEGRATION_VERSION = "1.0.7-alpha.2"
 MANUFACTURER = "PoolDigital GmbH & Co. KG"
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -17,7 +17,7 @@
     "aiohttp>=3.13.5",
     "violet-poolController-api==0.0.17"
   ],
-  "version": "1.0.7-alpha.1",
+  "version": "1.0.7-alpha.2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
- Fixed `.github/workflows/release.yml` to correctly move the tag to the new commit updating the version files and push it.
- Bumped integration version to `1.0.7-alpha.2` in `manifest.json` and `const.py`.

---
*PR created automatically by Jules for task [14951153005241038462](https://jules.google.com/task/14951153005241038462) started by @Xerolux*

## Summary by Sourcery

Update release workflow to correctly retag and push the release tag after version file updates, and bump the integration version to 1.0.7-alpha.2.

Bug Fixes:
- Fix release tagging so the tag points to the commit that updates changelog and version files.

Build:
- Adjust release workflow to move the release tag to the new commit and force-push it to the remote.

Deployment:
- Ensure release tags are updated on the correct commit in the remote repository during the release process.

Chores:
- Bump the violet_pool_controller integration version to 1.0.7-alpha.2 in code and manifest.