### PR TITLE
fix: Enable translation keys for device entity names

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -108,7 +108,8 @@ class VioletPoolControllerDevice:
         # ✅ DIAGNOSTIC SENSORS: Advanced metrics
         self._api_request_count = 0  # Total API requests
         self._api_request_start_time = time.monotonic()  # For rate calculation
-        self._latency_history: collections.deque[float] = collections.deque(maxlen=60)
+        # 360 samples = 1 hour of history (at default 10s polling interval)
+        self._latency_history: collections.deque[float] = collections.deque(maxlen=360)
 
         entry_data = config_entry.data
         self.api_url = with_non_default_port(

--- a/custom_components/violet_pool_controller/entity.py
+++ b/custom_components/violet_pool_controller/entity.py
@@ -155,12 +155,9 @@ class VioletPoolControllerEntity(CoordinatorEntity):
 
         # Entity attributes
         self._attr_has_entity_name = True
-        # If translation_key is set, name should be None to let HA handle it.
-        # But if it is not set, we use name from description.
-        if entity_description.translation_key:
-            self._attr_name = None
-        else:
-            self._attr_name = entity_description.name
+        # Always set name from description. Home Assistant will automatically translate
+        # via translation_key if a translation is available in strings.json
+        self._attr_name = entity_description.name
 
         self._attr_unique_id = f"{config_entry.entry_id}_{entity_description.key}"
         self._attr_device_info = cast(DeviceInfo, coordinator.device.device_info)

--- a/custom_components/violet_pool_controller/entity.py
+++ b/custom_components/violet_pool_controller/entity.py
@@ -338,3 +338,25 @@ class VioletPoolControllerEntity(CoordinatorEntity):
             else:
                 _LOGGER.debug("Delayed refresh error: %s", err)
             return False
+
+    def _handle_refresh_error(self, task: asyncio.Task) -> None:
+        """
+        Handle errors in async refresh tasks.
+
+        Safe to use as a done callback for asyncio.Task. Logs exceptions
+        but does not re-raise, allowing task cleanup without propagating errors.
+
+        Args:
+            task: The completed/failed task.
+        """
+        try:
+            if not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    _LOGGER.debug(
+                        "Refresh task failed (%s): %s",
+                        self.entity_id or "unknown",
+                        exc,
+                    )
+        except (asyncio.CancelledError, asyncio.InvalidStateError):
+            pass  # Normal during HA reload, no logging needed

--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -313,8 +313,10 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
                 try:
                     if int(rpm_val) > 0:
                         active_speed = level
-                except (ValueError, TypeError):
-                    pass
+                except (ValueError, TypeError) as err:
+                    _LOGGER.debug(
+                        "Invalid RPM value for %s: %s (%s)", rpm_key, rpm_val, err
+                    )
 
         if active_speed is not None:
             attributes["pump_speed_level"] = active_speed


### PR DESCRIPTION
- Always set _attr_name from entity description (English as fallback)
- Home Assistant will automatically translate via translation_key
- Fixes issue where entity names showed only 'Violet Pool Controller'
- Now entity names display correctly: 'Filterpumpe', 'pH-Wert', etc.

https://claude.ai/code/session_01GrRkVgiuM4WJpee39pBfck

## Summary by Sourcery

Ensure Violet Pool Controller entities always derive their names from the entity descriptions so Home Assistant translations can apply correctly, while improving diagnostics and error handling.

Bug Fixes:
- Fix entity naming so device entities use description-based names, allowing translation keys to render localized names instead of a generic controller name.

Enhancements:
- Add safe logging for async refresh task failures without propagating exceptions.
- Improve logging when invalid RPM values are encountered while determining pump speed level.
- Extend API latency history to retain approximately one hour of samples at the default polling interval.