### PR TITLE
fix: restore COVER_FUNCTIONS/DEVICE_PARAMETERS and bump to v1.2.1

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -41,7 +41,7 @@ from .const_sensors import *
 # =============================================================================
 
 DOMAIN = "violet_pool_controller"
-INTEGRATION_VERSION = "1.2.1.dev0"
+INTEGRATION_VERSION = "1.2.1"
 MANUFACTURER = "PoolDigital GmbH & Co. KG"
 
 # =============================================================================
@@ -75,13 +75,6 @@ ACTION_ALLON = "ALLON"
 ACTION_AUTO = "AUTO"
 ACTION_OFF = "OFF"
 ACTION_ON = "ON"
-
-# =============================================================================
-# COVER CONSTANTS
-# =============================================================================
-
-COVER_FUNCTIONS: dict[str, dict[str, str | bool]] = {}
-DEVICE_PARAMETERS: dict[str, dict[str, str]] = {}
 
 # Default Values
 DEFAULT_POLLING_INTERVAL = 10

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -16,12 +16,14 @@
   "requirements": [
     "violet-poolController-api>=0.0.24"
   ],
-  "version": "1.2.1.dev0",
+  "version": "1.2.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",
       "name": "violet*"
     },
-    "_violet-controller._tcp.local."
+    {
+      "type": "_violet-controller._tcp.local."
+    }
   ]
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

After the 1.2.1-dev bump, two critical constants were overwritten with empty dicts in `const.py`:

```python
COVER_FUNCTIONS: dict[str, dict[str, str | bool]] = {}   # broke cover open/close/stop
DEVICE_PARAMETERS: dict[str, dict[str, str]] = {}         # broke pump/heater/solar services
```

Both constants are imported (with real data) from the external `violet-poolController-api` package via `from violet_poolcontroller_api.const_api import *` and `from violet_poolcontroller_api.const_devices import *`. The local re-definitions silently overwrote them after the import, resulting in:

- **Cover control**: all OPEN/CLOSE/STOP commands raised `HomeAssistantError("Invalid cover action")` because `COVER_FUNCTIONS.get("OPEN")` returned `None`
- **Device services** (pump, dosing, etc.): `DEVICE_PARAMETERS.get(device_key, {})` always returned `{}`, breaking parameter lookups
- **"Integration not found"** WebSocket error caused by the broken integration state

## Changes

- **`const.py`**: Remove the two empty-dict overrides; let the star-imports supply the correct values
- **`const.py`**: Version `1.2.1.dev0` → `1.2.1` (proper semver release)
- **`manifest.json`**: Version `1.2.1.dev0` → `1.2.1`
- **`manifest.json`**: Standardize zeroconf entries to consistent dict format (string entry → `{"type": "..."}`)

The temperature fix (climate reads target temp from multiple field names) introduced in the recent commits is preserved.

## Test plan

- [ ] Cover open/close/stop commands work
- [ ] Pump service with speed control works
- [ ] Climate entity shows correct target temperature (not the 28°C default)
- [ ] No "Integration not found" error in HA logs after HA restart

https://claude.ai/code/session_01CpVtssoimYXxWnBeGP6wUN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpVtssoimYXxWnBeGP6wUN)_

## Summary by Sourcery

Restore correct cover and device constants from the external API and prepare the integration for the 1.2.1 release.

Bug Fixes:
- Fix broken cover actions by removing local empty COVER_FUNCTIONS override so imported values are used.
- Fix pump/heater and other device services by removing local empty DEVICE_PARAMETERS override so imported values are used.

Enhancements:
- Promote the integration version from 1.2.1.dev0 to the 1.2.1 release.
- Normalize zeroconf configuration entries in the manifest to a consistent object format.