### PR TITLE
fix(switch): dosing channels with _USE=0 correctly show as OFF

### DIFF
--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -30,6 +30,22 @@ _LOGGER = logging.getLogger(__name__)
 # Coordinator-based platforms; HA should not throttle entity state writes
 PARALLEL_UPDATES = 0
 
+
+def _dosing_switch_on(raw_state: Any, use_val: Any) -> bool | None:
+    """Determine ON/OFF for a dosing channel, honouring the _USE flag.
+
+    Args:
+        raw_state: The numeric state value for the dosing key (e.g. DOS_1_CL).
+        use_val:   The value of the matching {key}_USE key, or None if absent.
+
+    Returns:
+        False if use_val == "0" (channel disabled in controller config).
+        Otherwise delegates to the shared STATE_MAP interpretation.
+    """
+    if use_val is not None and str(use_val).strip() == "0":
+        return False
+    return interpret_state_as_bool(raw_state)
+
 # State Constants (matches DEVICE_STATE_MAPPING from API library)
 # - 0: Auto - Standby (OFF)
 # - 1: Auto - Active (Scheduled) (ON)
@@ -116,8 +132,13 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
         if raw_state is None:
             return None
 
-        # Use shared utility function
-        result = interpret_state_as_bool(raw_state, key)
+        # Dosing channels: delegate to _dosing_switch_on which honours _USE flag.
+        if key.startswith("DOS_"):
+            use_val = self.get_value(f"{key}_USE")
+            result = _dosing_switch_on(raw_state, use_val)
+        else:
+            # Use shared utility function
+            result = interpret_state_as_bool(raw_state, key)
 
         # Change-Only Logging
         if result != self._last_logged_state or raw_state != self._last_logged_raw:
@@ -326,6 +347,11 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
     def _enrich_dosing_attributes(self, attributes: dict[str, Any], key: str) -> None:
         """Add dosing-specific attributes: state details, remaining range,
         daily amount."""
+        # Whether this dosing channel is enabled in the controller config
+        use_val = self.get_value(f"{key}_USE")
+        if use_val is not None:
+            attributes["dosing_configured"] = str(use_val).strip() != "0"
+
         # Dosing state (e.g., DOS_1_CL_STATE = ['BLOCKED_BY_TRESHOLDS', ...])
         state_key = f"{key}_STATE"
         state_val = self.get_value(state_key)

--- a/tests/test_dosing_use_flag.py
+++ b/tests/test_dosing_use_flag.py
@@ -1,0 +1,69 @@
+"""Tests for dosing switch _USE flag: disabled channels must show as OFF.
+
+The core logic lives in switch._dosing_switch_on(), a pure function that can be
+tested without any Home Assistant infrastructure (mirrors test_entity_state.py).
+"""
+import pytest
+
+from custom_components.violet_pool_controller.switch import _dosing_switch_on
+
+
+class TestDosingUseFlagPureFunction:
+    """_dosing_switch_on(raw_state, use_val) – unit-test the pure helper."""
+
+    # --- _USE = "0" → always False, regardless of state ---
+
+    @pytest.mark.parametrize("state", [0, 1, 2, 3, 4, 5, 6])
+    def test_use_zero_forces_off_for_all_states(self, state):
+        """`_USE = '0'` must override every numeric state."""
+        assert _dosing_switch_on(state, "0") is False
+
+    def test_use_zero_string_variant(self):
+        """String '0' with surrounding whitespace still disabled."""
+        assert _dosing_switch_on(2, " 0 ") is False
+
+    # --- _USE = "1" → normal STATE_MAP logic ---
+
+    def test_use_one_state_2_is_on(self):
+        """Chlor channel: state=2, _USE=1 → ON (from STATE_MAP)."""
+        assert _dosing_switch_on(2, "1") is True
+
+    def test_use_one_state_0_is_off(self):
+        """pH- channel: state=0 (AUTO_OFF), _USE=1 → OFF."""
+        assert _dosing_switch_on(0, "1") is False
+
+    def test_use_one_state_4_is_on(self):
+        """state=4 (MANUAL_ON_FORCED), _USE=1 → ON."""
+        assert _dosing_switch_on(4, "1") is True
+
+    # --- _USE absent (None) → normal STATE_MAP logic ---
+
+    def test_no_use_key_state_2_falls_back_to_state_map(self):
+        """No _USE key: state=2 → True per STATE_MAP."""
+        assert _dosing_switch_on(2, None) is True
+
+    def test_no_use_key_state_0_is_off(self):
+        """No _USE key: state=0 → False per STATE_MAP."""
+        assert _dosing_switch_on(0, None) is False
+
+    # --- Real-world values from the user's JSON ---
+
+    def test_elo_not_in_use(self):
+        """DOS_2_ELO: state=2, USE='0' (Elektrolyse disabled) → OFF."""
+        assert _dosing_switch_on(2, "0") is False
+
+    def test_floc_not_in_use(self):
+        """DOS_6_FLOC: state=2, USE='0' (Flockmittel disabled) → OFF."""
+        assert _dosing_switch_on(2, "0") is False
+
+    def test_php_not_in_use(self):
+        """DOS_5_PHP: state=2, USE='0' (pH+ disabled) → OFF."""
+        assert _dosing_switch_on(2, "0") is False
+
+    def test_chlor_in_use(self):
+        """DOS_1_CL: state=2, USE='1' (Chlor active) → ON."""
+        assert _dosing_switch_on(2, "1") is True
+
+    def test_phm_in_use(self):
+        """DOS_4_PHM: state=2, USE='1' (pH- active) → ON."""
+        assert _dosing_switch_on(2, "1") is True


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

The HA UI showed Elektrolyse, Flockmittel, and pH+ as **ON** (blue toggle) even though the user had not configured these dosing channels for use. The controller correctly reports `DOS_*_USE = "0"` for disabled channels, but the integration ignored this flag and mapped the numeric state value `2` (AUTO_ACTIVE) to `True` via `STATE_MAP`.

**Root cause:** `_get_switch_state()` called `interpret_state_as_bool(raw_state)` which uses `STATE_MAP[2] = True`, without checking the `_USE` flag that indicates whether the dosing channel is actually configured.

**Affected channels from user JSON:**
| Channel | State | `_USE` | Daily amount | Runtime | Was shown |
|---------|-------|--------|-------------|---------|-----------|
| DOS_2_ELO (Elektrolyse) | 2 | `"0"` | 0 ml | 00:00 | ON ❌ |
| DOS_5_PHP (pH+) | 2 | `"0"` | 0 ml | 00:00 | ON ❌ |
| DOS_6_FLOC (Flockmittel) | 2 | `"0"` | 0 ml | 00:00 | ON ❌ |
| DOS_1_CL (Chlor) | 2 | `"1"` | 43 ml | 02:41 | ON ✅ |
| DOS_4_PHM (pH-) | 2 | `"1"` | 306 ml | 19:18 | ON ✅ |

## Solution

- Added `_dosing_switch_on(raw_state, use_val)` pure function in `switch.py` that returns `False` when `use_val == "0"`, otherwise delegates to the shared `interpret_state_as_bool`.
- `_get_switch_state()` now calls this function for all `DOS_*` keys.
- `_enrich_dosing_attributes()` now exposes `dosing_configured: bool` as an entity attribute, so users can see the configured status in the HA device detail view.

## Tests

- `tests/test_dosing_use_flag.py` — 18 parametrised tests covering all state/USE combinations including the exact values from the user's `getReadings` JSON. All pass locally without HA infrastructure (same pattern as `test_entity_state.py`).

## Summary

- What changed: `switch.py` (2 methods + 1 new pure function), `tests/test_dosing_use_flag.py` (new)
- No API changes needed — `_USE` data is already present in the `getReadings` response

https://claude.ai/code/session_017dBbsQ6Le9pE2JxLMUoaHR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017dBbsQ6Le9pE2JxLMUoaHR)_

## Summary by Sourcery

Honor controller dosing channel configuration flags when determining switch states and expose configuration status as an attribute.

Bug Fixes:
- Ensure dosing switches report OFF when their corresponding _USE flag indicates the channel is disabled, even if the raw state would otherwise map to ON.

Enhancements:
- Add a helper to centralize dosing switch ON/OFF evaluation using the dosing _USE flag and existing state interpretation.
- Expose a dosing_configured attribute on dosing entities to reflect whether the channel is enabled in the controller configuration.

Tests:
- Add unit tests for dosing switch behavior across all combinations of state values and _USE flags, including real-world examples from user data.