### PR TITLE
chore(deps): upgrade violet-poolController-api to >=0.0.25

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ pytest tests/test_api.py::test_function_name -v
 
 - **`__init__.py`** - Integration entry point. Handles setup, config entry migration, platform loading, and service registration. Loads these platforms: `sensor`, `binary_sensor`, `switch`, `climate`, `cover`, `number`, `select`.
 
-- **External API package** (`violet-poolController-api==0.0.22` on PyPI) - The HTTP client and low-level utilities are **not** in this repo; they ship as an external package. Provides:
+- **External API package** (`violet-poolController-api>=0.0.25` on PyPI) - The HTTP client and low-level utilities are **not** in this repo; they ship as an external package. Provides:
   - `VioletPoolAPI` class - rate-limited HTTP client with retry/backoff
   - `VioletPoolAPIError` exception hierarchy
   - `InputSanitizer` - XSS/injection/path-traversal protection
@@ -556,7 +556,7 @@ Located in `.github/workflows/`:
 - `voluptuous>=0.16.0` - Data validation
 
 **Integration requirement** (from `manifest.json`):
-- `violet-poolController-api==0.0.22` - External API client package (installed by HA automatically)
+- `violet-poolController-api>=0.0.25` - External API client package (installed by HA automatically)
 
 **Development** (from `requirements-dev.txt`):
 - `ruff>=0.15.14` - Linter and formatter

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/xerolux/violet-hass/issues",
   "quality_scale": "platinum",
   "requirements": [
-    "violet-poolController-api==0.0.24"
+    "violet-poolController-api>=0.0.25"
   ],
   "version": "1.2.1",
   "zeroconf": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 homeassistant>=2026.5.0
 aiohttp>=3.13.5
 voluptuous>=0.15.2
-violet-poolController-api==0.0.24
+violet-poolController-api>=0.0.25


### PR DESCRIPTION
Switches from pinned ==0.0.24 to >=0.0.25 so future patch/minor releases of the API package are picked up automatically without manual version bumps.

## Summary by Sourcery

Relax and update the violet-poolController-api dependency version to track patch/minor releases.

Build:
- Change Home Assistant integration requirements to use violet-poolController-api>=0.0.25 instead of a pinned 0.0.24 version.

Documentation:
- Update documentation to reference violet-poolController-api>=0.0.25 as the external API dependency.