### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -41,7 +41,7 @@ from .const_sensors import *
 # =============================================================================
 
 DOMAIN = "violet_pool_controller"
-INTEGRATION_VERSION = "1.2.1"
+INTEGRATION_VERSION = "1.2.2"
 MANUFACTURER = "PoolDigital GmbH & Co. KG"
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -16,7 +16,7 @@
   "requirements": [
     "violet-poolController-api>=0.0.25"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the integration version metadata in the manifest to 1.2.2.