### PR TITLE
Fix state_class for dosing can amount sensors

### DIFF
--- a/custom_components/violet_pool_controller/sensor_modules/base.py
+++ b/custom_components/violet_pool_controller/sensor_modules/base.py
@@ -310,6 +310,9 @@ def determine_state_class(key: str) -> SensorStateClass | None:
     # (they are counters, not measurements)
     if "freezecount" in key.lower() or "faultcount" in key.lower():
         return None
+    # Dosing can amount sensors (DOS_*_TOTAL_CAN_AMOUNT_ML) can decrease on refill
+    if "dos_" in key.lower() and "_total_can_amount_" in key.lower():
+        return SensorStateClass.MEASUREMENT
     if "total" in key.lower() or "daily" in key.lower():
         return SensorStateClass.TOTAL_INCREASING
     return SensorStateClass.MEASUREMENT


### PR DESCRIPTION
## Summary

Fixed Home Assistant logger warnings for dosing can amount sensors (`DOS_*_TOTAL_CAN_AMOUNT_ML`) that were incorrectly marked with `state_class=total_increasing`. These sensors represent remaining chemical amounts that can decrease when cans are refilled or reset.

## Changes

- Modified `determine_state_class()` in `sensor_modules/base.py` to exclude dosing can amount sensors from `TOTAL_INCREASING` classification
- Changed their state class to `MEASUREMENT` since values can decrease

## Resolves

Home Assistant recorder warnings:
- `Entity sensor.violet_pool_controller_dos_4_phm_total_can_amount_ml has state class total_increasing, but its state is not strictly increasing`
- `Entity sensor.violet_pool_controller_dos_1_cl_total_can_amount_ml has state class total_increasing, but its state is not strictly increasing`

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wfp7mLVUNsHfE7sYYu7GN)_

## Summary by Sourcery

Bug Fixes:
- Set dosing can amount sensors to use MEASUREMENT state class instead of TOTAL_INCREASING so their decreasing values no longer trigger Home Assistant recorder warnings.