### PR TITLE
Upgrade to version 1.2.3-dev

### DIFF
--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -41,7 +41,7 @@ from .const_sensors import *
 # =============================================================================
 
 DOMAIN = "violet_pool_controller"
-INTEGRATION_VERSION = "1.2.2"
+INTEGRATION_VERSION = "1.2.3-dev"
 MANUFACTURER = "PoolDigital GmbH & Co. KG"
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/manifest.json
+++ b/custom_components/violet_pool_controller/manifest.json
@@ -16,7 +16,7 @@
   "requirements": [
     "violet-poolController-api>=0.0.25"
   ],
-  "version": "1.2.2",
+  "version": "1.2.3-dev",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
Updated version number in manifest.json and const.py to 1.2.3-dev for development builds.

## Summary by Sourcery

Build:
- Update integration version field in manifest.json to 1.2.3-dev.