### PR TITLE
docs: update broken HACS download URLs

### DIFF
--- a/Dashboard/DASHBOARD_GUIDE.md
+++ b/Dashboard/DASHBOARD_GUIDE.md
@@ -97,7 +97,7 @@ Ich habe zwei neue Dashboard-Vorlagen erstellt, die **ALLE Einstellungen für je
 
 #### Benötigte Custom Cards:
 
-1. **HACS** installieren (falls noch nicht): https://hacs.xyz/docs/setup/download
+1. **HACS** installieren (falls noch nicht): https://hacs.xyz/docs/use/download/download/
 2. **HACS** → **Frontend** → Suche nach:
    - **Mushroom**
    - **Slider Entity Row**

--- a/README.de.md
+++ b/README.de.md
@@ -82,7 +82,7 @@ Die vollständige Dokumentation befindet sich im **[Wiki][wiki]**:
 ## 🔑 Voraussetzungen
 
 - Home Assistant **2026.5.0+** (getestet bis 2026.x)
-- HACS ([Installationsanleitung](https://hacs.xyz/docs/setup/download))
+- HACS ([Installationsanleitung](https://hacs.xyz/docs/use/download/download/))
 - Violet Pool Controller im lokalen Netzwerk erreichbar
 - Python 3.14.2+
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The full documentation is available in the **[Wiki][wiki]**:
 ## 🔑 Requirements
 
 - Home Assistant **2026.5.0+** (tested up to 2026.x)
-- HACS ([Installation guide](https://hacs.xyz/docs/setup/download))
+- HACS ([Installation guide](https://hacs.xyz/docs/use/download/download/))
 - Violet Pool Controller accessible on your local network
 - Python 3.14.2+
 

--- a/docs/public/index.de.md
+++ b/docs/public/index.de.md
@@ -79,7 +79,7 @@ Die vollständige Dokumentation befindet sich im **[Wiki][wiki]**:
 ## 🔑 Voraussetzungen
 
 - Home Assistant **2026.5.0+** (getestet bis 2026.x)
-- HACS ([Installationsanleitung](https://hacs.xyz/docs/setup/download))
+- HACS ([Installationsanleitung](https://hacs.xyz/docs/use/download/download/))
 - Violet Pool Controller im lokalen Netzwerk erreichbar
 - Python 3.14.2+
 

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -79,7 +79,7 @@ The complete documentation is available in the **[Wiki][wiki]**:
 ## 🔑 Requirements
 
 - Home Assistant **2026.5.0+** (tested up to 2026.x)
-- HACS ([Installation Guide](https://hacs.xyz/docs/setup/download))
+- HACS ([Installation Guide](https://hacs.xyz/docs/use/download/download/))
 - Violet Pool Controller accessible on the local network
 - Python 3.14.2+
 

--- a/docs/wiki/Installation-and-Setup.de.md
+++ b/docs/wiki/Installation-and-Setup.de.md
@@ -51,7 +51,7 @@ HACS (Home Assistant Community Store) ermöglicht einfache Installation und auto
 
 ### Schritt 1: HACS installieren (falls noch nicht vorhanden)
 
-Falls HACS noch nicht installiert ist, folge der [offiziellen HACS-Installationsanleitung](https://hacs.xyz/docs/setup/download).
+Falls HACS noch nicht installiert ist, folge der [offiziellen HACS-Installationsanleitung](https://hacs.xyz/docs/use/download/download/).
 
 ### Schritt 2: Repository hinzufügen
 

--- a/docs/wiki/Installation-and-Setup.md
+++ b/docs/wiki/Installation-and-Setup.md
@@ -51,7 +51,7 @@ HACS (Home Assistant Community Store) enables easy installation and automatic up
 
 ### Step 1: Install HACS (if not already installed)
 
-If HACS is not yet installed, follow the [official HACS installation guide](https://hacs.xyz/docs/setup/download).
+If HACS is not yet installed, follow the [official HACS installation guide](https://hacs.xyz/docs/use/download/download/).
 
 ### Step 2: Add Repository
 


### PR DESCRIPTION
Fixes broken HACS documentation links in markdown files.

---
*PR created automatically by Jules for task [1918828634815123522](https://jules.google.com/task/1918828634815123522) started by @Xerolux*

## Summary by Sourcery

Documentation:
- Replace outdated HACS setup/download links with the new official HACS download URLs across README, dashboard guide, and installation docs.