### PR TITLE
fix: Status-Mapping an Original-Controller angleichen, CI/Test-Setup reparieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Home Assistant custom integration for the **Violet Pool Controller** by PoolDigital GmbH & Co. KG. It enables local polling-based control and monitoring of pool systems including pumps, heaters, solar, chemical dosing, lighting, and covers.
 
-**Current Version**: `1.2.3` (defined in `manifest.json` and `const.py`)
+**Current Version**: `1.2.4-dev` (defined in `manifest.json` and `const.py`)
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ pytest tests/test_api.py::test_function_name -v
   - Heater control
   - Solar control
   - Dosing systems (pH-, pH+, Chlorine, Flocculant)
-  - DMX scenes (1-8)
+  - DMX scenes (1-12)
   - Extension relays (1-8)
   - Multi-state support (0-6) with automatic mode detection
 
@@ -219,7 +219,7 @@ Services defined in `services.yaml` and registered in `services.py`:
   - Integration with solar systems
 
 - **`control_dmx_scenes`** - DMX lighting control:
-  - Scene selection (1-8)
+  - Scene selection (1-12)
   - Scene activation/deactivation
 
 - **`set_light_color_pulse`** - Pool light control:
@@ -237,14 +237,18 @@ Services defined in `services.yaml` and registered in `services.py`:
 
 2. **Rate Limiting**: API requests go through a global rate limiter (provided by the external `violet-poolController-api` package) using token bucket algorithm to protect the controller from overload.
 
-3. **Multi-State Switches**: Pool devices support multiple states (0-6):
-   - `0` = AUTO_OFF (automatic control, currently off)
-   - `1` = AUTO_ON (automatic control, currently on)
-   - `2` = AUTO_ACTIVE (automatic control with timing)
-   - `3` = AUTO_ACTIVE_TIMER (automatic control with timer)
-   - `4` = MANUAL_ON_FORCED (manual on, forced mode)
-   - `5` = AUTO_WAITING (automatic control, waiting for conditions)
-   - `6` = MANUAL_OFF (manual off)
+3. **Multi-State Switches**: Pool devices support multiple states (0-6), per the
+   getReadings spec and `DEVICE_STATE_MAPPING` in the external API package:
+   - `0` = Auto - Standby (off)
+   - `1` = Auto - Active/Scheduled (on)
+   - `2` = Auto - Priority OFF, blocked by control rule (off)
+   - `3` = Auto - Priority ON by emergency rule (on)
+   - `4` = Manual ON, forced (on)
+   - `5` = OFF by emergency rule (off)
+   - `6` = Manual OFF (off)
+
+   Exception: `PVSURPLUS` uses its own scheme (0 = off, 1 = on via digital
+   input, 2 = on via HTTP request).
 
    **Important**: States may include descriptive suffixes (e.g., `"3|PUMP_ANTI_FREEZE"`) parsed as operational modes like frost protection.
 
@@ -568,11 +572,11 @@ Located in `.github/workflows/`:
 
 ## Important Notes
 
-1. **Thread Safety**: The integration uses two locks (`_api_lock`, `_recovery_lock`) with documented ordering. Always read device.py:42-58 before modifying concurrent code to prevent deadlocks.
+1. **Thread Safety**: The coordinator serializes polling with a single `_api_lock` (see device.py). Service handlers call the API directly; command serialization is handled by the external package's rate limiter.
 
 2. **State Handling**: Switches support states 0-6 with specific meanings:
-   - States 0, 5, 6 = Device OFF (different automatic/manual modes)
-   - States 1, 2, 3, 4 = Device ON (different automatic/manual modes)
+   - States 0, 2, 5, 6 = Device OFF (standby, rule-blocked, emergency rule, manual off)
+   - States 1, 3, 4 = Device ON (scheduled, emergency-rule priority, manual forced)
    - Composite states like `"3|PUMP_ANTI_FREEZE"` provide additional context about operational modes
    - All states are defined in `DEVICE_STATE_MAPPING` inside the external `violet-poolController-api` package (`const_devices` module)
 

--- a/custom_components/violet_pool_controller/climate.py
+++ b/custom_components/violet_pool_controller/climate.py
@@ -49,6 +49,8 @@ STATE_MANUAL_OFF = 6
 # Temperature limits
 DEFAULT_MIN_TEMP = 20.0
 DEFAULT_MAX_TEMP = 35.0
+# Solar absorbers go up to 40 °C, matching the solar_setpoint number entity
+SOLAR_MAX_TEMP = 40.0
 DEFAULT_TARGET_TEMP = 28.0
 TEMP_STEP = 0.5
 
@@ -156,6 +158,11 @@ class VioletClimateEntity(VioletPoolControllerEntity, ClimateEntity):
 
         super().__init__(coordinator, config_entry, climate_description)
         self.climate_type = climate_type
+
+        # Solar absorbers allow up to 40 °C (matches the solar_setpoint
+        # number entity); heaters stay at the 35 °C default
+        if climate_type == "SOLAR":
+            self._attr_max_temp = SOLAR_MAX_TEMP
 
         # FIXED: Local cache variables for optimistic updates
         self._optimistic_target_temp: float | None = None

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -36,6 +36,26 @@ from violet_poolcontroller_api.const_devices import *
 from .const_features import *
 from .const_sensors import *
 
+# Explicit re-imports so that type checkers see these names (the external
+# package ships no py.typed marker, so wildcard imports are opaque to mypy)
+from violet_poolcontroller_api.const_api import (
+    ACTION_ALLAUTO,
+    ACTION_ALLOFF,
+    ACTION_ALLON,
+    ACTION_AUTO,
+    ACTION_COLOR,
+    ACTION_LOCK,
+    ACTION_MAN,
+    ACTION_OFF,
+    ACTION_ON,
+    ACTION_PUSH,
+    ACTION_UNLOCK,
+)
+from violet_poolcontroller_api.const_devices import (
+    COVER_FUNCTIONS,
+    DEVICE_PARAMETERS,
+)
+
 # =============================================================================
 # INTEGRATION INFO
 # =============================================================================
@@ -64,17 +84,8 @@ CONF_DISINFECTION_METHOD = "disinfection_method"
 CONF_ENABLE_DIAGNOSTIC_LOGGING = "enable_diagnostic_logging"
 CONF_DOSING_STANDALONE = "dosing_standalone"
 
-# =============================================================================
-# ACTION CONSTANTS
-# =============================================================================
-
-ACTION_PUSH = "PUSH"
-ACTION_ALLAUTO = "ALLAUTO"
-ACTION_ALLOFF = "ALLOFF"
-ACTION_ALLON = "ALLON"
-ACTION_AUTO = "AUTO"
-ACTION_OFF = "OFF"
-ACTION_ON = "ON"
+# ACTION_* constants come from violet_poolcontroller_api.const_api (wildcard
+# import above) - do not redefine them here, local copies drift from the API.
 
 # Default Values
 DEFAULT_POLLING_INTERVAL = 10
@@ -106,11 +117,8 @@ DISINFECTION_METHODS = ["chlorine", "salt", "bromine", "active_oxygen", "uv", "o
 # They map high-level control actions to protocol command strings recognized
 # by the Violet Pool Controller API.
 
-COVER_FUNCTIONS: dict[str, str | None] = {
-    "OPEN": "COVER_OPEN",
-    "CLOSE": "COVER_CLOSE",
-    "STOP": "COVER_STOP",
-}
+# COVER_FUNCTIONS and DEVICE_PARAMETERS come from
+# violet_poolcontroller_api.const_devices (wildcard import above).
 
 # Maps the controller's numeric COVER_STATE values to the high-level cover
 # states consumed by cover.py (is_open / is_closed / is_opening / is_closing).
@@ -126,8 +134,6 @@ COVER_STATE_MAP: dict[str, str] = {
     "CLOSING": "closing",
     "STOPPED": "stopped",
 }
-
-DEVICE_PARAMETERS: dict[str, dict[str, str]] = {}
 
 # =============================================================================
 # VERSION INFO

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -36,24 +36,25 @@ from violet_poolcontroller_api.const_devices import *
 from .const_features import *
 from .const_sensors import *
 
-# Explicit re-imports so that type checkers see these names (the external
-# package ships no py.typed marker, so wildcard imports are opaque to mypy)
+# Explicit re-exports ("X as X" marks them as intentional) so that type
+# checkers see these names - the external package ships no py.typed marker,
+# so the wildcard imports above are opaque to mypy
 from violet_poolcontroller_api.const_api import (
-    ACTION_ALLAUTO,
-    ACTION_ALLOFF,
-    ACTION_ALLON,
-    ACTION_AUTO,
-    ACTION_COLOR,
-    ACTION_LOCK,
-    ACTION_MAN,
-    ACTION_OFF,
-    ACTION_ON,
-    ACTION_PUSH,
-    ACTION_UNLOCK,
+    ACTION_ALLAUTO as ACTION_ALLAUTO,
+    ACTION_ALLOFF as ACTION_ALLOFF,
+    ACTION_ALLON as ACTION_ALLON,
+    ACTION_AUTO as ACTION_AUTO,
+    ACTION_COLOR as ACTION_COLOR,
+    ACTION_LOCK as ACTION_LOCK,
+    ACTION_MAN as ACTION_MAN,
+    ACTION_OFF as ACTION_OFF,
+    ACTION_ON as ACTION_ON,
+    ACTION_PUSH as ACTION_PUSH,
+    ACTION_UNLOCK as ACTION_UNLOCK,
 )
 from violet_poolcontroller_api.const_devices import (
-    COVER_FUNCTIONS,
-    DEVICE_PARAMETERS,
+    COVER_FUNCTIONS as COVER_FUNCTIONS,
+    DEVICE_PARAMETERS as DEVICE_PARAMETERS,
 )
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -36,26 +36,25 @@ from violet_poolcontroller_api.const_devices import *
 from .const_features import *
 from .const_sensors import *
 
-# Explicit re-exports ("X as X" marks them as intentional) so that type
-# checkers see these names - the external package ships no py.typed marker,
-# so the wildcard imports above are opaque to mypy
-from violet_poolcontroller_api.const_api import (
-    ACTION_ALLAUTO as ACTION_ALLAUTO,
-    ACTION_ALLOFF as ACTION_ALLOFF,
-    ACTION_ALLON as ACTION_ALLON,
-    ACTION_AUTO as ACTION_AUTO,
-    ACTION_COLOR as ACTION_COLOR,
-    ACTION_LOCK as ACTION_LOCK,
-    ACTION_MAN as ACTION_MAN,
-    ACTION_OFF as ACTION_OFF,
-    ACTION_ON as ACTION_ON,
-    ACTION_PUSH as ACTION_PUSH,
-    ACTION_UNLOCK as ACTION_UNLOCK,
-)
-from violet_poolcontroller_api.const_devices import (
-    COVER_FUNCTIONS as COVER_FUNCTIONS,
-    DEVICE_PARAMETERS as DEVICE_PARAMETERS,
-)
+# Explicit re-exports via assignment so that both type checkers and static
+# analysis see these names as defined and used here - the external package
+# ships no py.typed marker, so the wildcard imports above are opaque to mypy
+from violet_poolcontroller_api import const_api as _const_api
+from violet_poolcontroller_api import const_devices as _const_devices
+
+ACTION_ALLAUTO = _const_api.ACTION_ALLAUTO
+ACTION_ALLOFF = _const_api.ACTION_ALLOFF
+ACTION_ALLON = _const_api.ACTION_ALLON
+ACTION_AUTO = _const_api.ACTION_AUTO
+ACTION_COLOR = _const_api.ACTION_COLOR
+ACTION_LOCK = _const_api.ACTION_LOCK
+ACTION_MAN = _const_api.ACTION_MAN
+ACTION_OFF = _const_api.ACTION_OFF
+ACTION_ON = _const_api.ACTION_ON
+ACTION_PUSH = _const_api.ACTION_PUSH
+ACTION_UNLOCK = _const_api.ACTION_UNLOCK
+COVER_FUNCTIONS = _const_devices.COVER_FUNCTIONS
+DEVICE_PARAMETERS = _const_devices.DEVICE_PARAMETERS
 
 # =============================================================================
 # INTEGRATION INFO

--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -408,8 +408,8 @@ for i in range(1, 13):
             "entity_registry_enabled_default": False,
         }
     )
-# Dynamically add digital rules
-for i in range(1, 9):
+# Dynamically add digital rules (controller exposes DIRULE_1..7)
+for i in range(1, 8):
     SWITCHES.append(
         {
             "key": f"DIRULE_{i}",
@@ -467,8 +467,10 @@ SETPOINT_DEFINITIONS = [
         "name": "ORP Setpoint",
         "translation_key": "orp_setpoint",
         "api_key": "ORP",
-        "min_value": 100,
-        "max_value": 1000,
+        # InputSanitizer.validate_orp_value clamps writes to 400-900 mV;
+        # a wider UI range would be silently rewritten on save
+        "min_value": 400,
+        "max_value": 900,
         "step": 5,
         "default_value": 700,
         "icon": "mdi:lightning-bolt-circle",

--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -15,6 +15,8 @@ based on the user's enabled features and the data available from the controller.
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.helpers.entity import EntityCategory
@@ -645,7 +647,7 @@ SETPOINT_DEFINITIONS = [
 # SELECT CONTROLS - ON/OFF/AUTO Control
 # =============================================================================
 
-SELECT_CONTROLS = [
+SELECT_CONTROLS: list[dict[str, Any]] = [
     {
         "key": "pump_mode",
         "name": "Pump Mode",

--- a/custom_components/violet_pool_controller/const_sensors.py
+++ b/custom_components/violet_pool_controller/const_sensors.py
@@ -160,7 +160,8 @@ SYSTEM_SENSORS = {
         "translation_key": "system_carrier_cpu_temperature",
         "icon": "mdi:memory",
     },
-    "SYSTEM_DOSAGEMODULE_CPU_TEMPERATURE": {
+    # Spec key is lowercase: SYSTEM_dosagemodule_cpu_temperature
+    "SYSTEM_dosagemodule_cpu_temperature": {
         "name": "Dosing Module CPU Temperature",
         "translation_key": "system_dosagemodule_cpu_temperature",
         "icon": "mdi:memory-lan",
@@ -450,7 +451,8 @@ NO_UNIT_SENSORS = {
     "CPU_GOV",
     "SYSTEM_CPU_TEMPERATURE",
     "SYSTEM_CARRIER_CPU_TEMPERATURE",
-    "SYSTEM_DOSAGEMODULE_CPU_TEMPERATURE",
+    # SYSTEM_dosagemodule_cpu_temperature deliberately not listed: it is a
+    # FLOAT in °C and must keep its temperature unit
     "SYSTEM_memoryusage",
     *(f"PUMP_RPM_{i}" for i in range(4)),
     "PUMP_RUNTIME",

--- a/custom_components/violet_pool_controller/cover.py
+++ b/custom_components/violet_pool_controller/cover.py
@@ -70,9 +70,13 @@ class VioletCover(VioletPoolControllerEntity, CoverEntity):
         return COVER_STATE_MAP.get(raw.upper(), "")
 
     @property
-    def is_closed(self) -> bool:
-        """Return True if the cover is closed."""
-        return self._map_cover_state() == "closed"
+    def is_closed(self) -> bool | None:
+        """Return True if the cover is closed, None if the state is unknown."""
+        state = self._map_cover_state()
+        if not state:
+            # Unknown/unmapped COVER_STATE must not be reported as "open"
+            return None
+        return state == "closed"
 
     @property
     def is_opening(self) -> bool:

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -585,6 +585,10 @@ class VioletPoolControllerDevice:
 
                 return dict(self._data)
 
+        except UpdateFailed:
+            # Already counted and logged where it was raised - the generic
+            # handler below must not increment the failure counter again
+            raise
         except VioletPoolAPIError as err:
             self._last_error = str(err)
             self._consecutive_failures += 1

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -52,6 +52,7 @@ from .const import (
     DEFAULT_POLLING_INTERVAL,
     DEFAULT_RETRY_ATTEMPTS,
     DEFAULT_TIMEOUT_DURATION,
+    DEFAULT_USE_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
 )
@@ -124,7 +125,7 @@ class VioletPoolControllerDevice:
             extract_api_host(entry_data),
             entry_data.get(CONF_PORT, DEFAULT_PORT),
         )
-        self.use_ssl = entry_data.get(CONF_USE_SSL, True)
+        self.use_ssl = entry_data.get(CONF_USE_SSL, DEFAULT_USE_SSL)
         self.device_id = entry_data.get(CONF_DEVICE_ID, 1)
         self.device_name = entry_data.get(CONF_DEVICE_NAME, "Violet Pool Controller")
         # Prefer options (later changes) over data
@@ -418,6 +419,9 @@ class VioletPoolControllerDevice:
 
                 if not data or not isinstance(data, dict):
                     self._consecutive_failures += 1
+                    # Allow the recovery message/issue cleanup to fire again
+                    # after this new outage
+                    self._recovery_logged = False
                     if self._consecutive_failures == 1:
                         if self._available or len(self._data) > 0:
                             _LOGGER.warning(
@@ -478,8 +482,14 @@ class VioletPoolControllerDevice:
                     config_data = await self.api.get_config(config_keys)
                     if isinstance(config_data, dict):
                         data.update(config_data)
-                except VioletPoolAPIError:
-                    pass
+                except Exception as err:  # noqa: BLE001
+                    # Setpoints are an optional enrichment - a failure here
+                    # must not invalidate the successful readings poll
+                    _LOGGER.debug(
+                        "Optional getConfig fetch failed for '%s': %s",
+                        self.device_name,
+                        err,
+                    )
 
                 if self._consecutive_failures > 0 and not self._recovery_logged:
                     _LOGGER.info(
@@ -578,6 +588,7 @@ class VioletPoolControllerDevice:
         except VioletPoolAPIError as err:
             self._last_error = str(err)
             self._consecutive_failures += 1
+            self._recovery_logged = False
             if self._consecutive_failures == 1:
                 if not self._available and len(self._data) == 0:
                     _LOGGER.debug("API error during setup of '%s': %s", self.device_name, str(err)[:200])
@@ -594,6 +605,7 @@ class VioletPoolControllerDevice:
         except Exception as err:
             self._last_error = str(err)
             self._consecutive_failures += 1
+            self._recovery_logged = False
             if self._consecutive_failures == 1:
                 if not self._available and len(self._data) == 0:
                     _LOGGER.debug("Error during setup of '%s': %s", self.device_name, err)

--- a/custom_components/violet_pool_controller/entity.py
+++ b/custom_components/violet_pool_controller/entity.py
@@ -28,23 +28,28 @@ _LOGGER = logging.getLogger(__name__)
 # =============================================================================
 
 # Boolean State Mapping (used by switches and other boolean entities)
-# States per device specifications:
-# 0 = AUTO_OFF (automatic control, currently off)
-# 1 = AUTO_ON (automatic control, currently on)
-# 2 = AUTO_ACTIVE (automatic control with timing)
-# 3 = AUTO_ACTIVE_TIMER (automatic control with timer)
-# 4 = MANUAL_ON_FORCED (manual on, forced mode)
-# 5 = AUTO_WAITING (automatic control, waiting for conditions)
-# 6 = MANUAL_OFF (manual off)
+# States per getReadings spec (Rev. 14-07-2024) and
+# violet_poolcontroller_api.const_devices.DEVICE_STATE_MAPPING:
+# 0 = Auto - Standby (off)
+# 1 = Auto - Active/Scheduled (on)
+# 2 = Auto - Priority OFF, blocked by control rule (off)
+# 3 = Auto - Priority ON by emergency rule (on)
+# 4 = Manual ON, forced (on)
+# 5 = OFF by emergency rule (off)
+# 6 = Manual OFF (off)
 STATE_MAP = {
-    0: False,  # AUTO_OFF
-    1: True,   # AUTO_ON
-    2: True,   # AUTO_ACTIVE (with timing, device is active)
-    3: True,   # AUTO_ACTIVE_TIMER (with timer, device is active)
-    4: True,   # MANUAL_ON_FORCED
-    5: False,  # AUTO_WAITING (not yet active)
-    6: False,  # MANUAL_OFF
+    0: False,  # Auto - Standby
+    1: True,   # Auto - Active (Scheduled)
+    2: False,  # Auto - Priority OFF (Rule Blocked)
+    3: True,   # Auto - Priority ON (Emergency Rule)
+    4: True,   # Manual ON (Forced)
+    5: False,  # Rule OFF (Emergency Rule)
+    6: False,  # Manual OFF
 }
+
+# PVSURPLUS does not use the 0-6 output state scheme:
+# 0 = off, 1 = on (digital input), 2 = on (HTTP request)
+PV_SURPLUS_STATE_MAP = {0: False, 1: True, 2: True}
 
 
 # Pre-compiled numeric pattern for performance
@@ -114,14 +119,16 @@ def interpret_state_as_bool(raw_state: Any, key: str = "") -> bool | None:
         return None
 
     state_str = str(raw_state).upper().strip()
-    if state_str in ("N/A", "NONE", "UNKNOWN", "NULL"):
+    if state_str in ("N/A", "NONE", "UNKNOWN", "NULL", "---", ""):
         return None
+
+    state_map = PV_SURPLUS_STATE_MAP if key == "PVSURPLUS" else STATE_MAP
 
     # Priority 1: Check STATE_MAP first (most common)
     state_int = convert_to_int(raw_state)
     if state_int is not None:
-        if state_int in STATE_MAP:
-            return STATE_MAP[state_int]
+        if state_int in state_map:
+            return state_map[state_int]
         # Generic interpretation: 0 = False, non-zero = True
         return state_int != 0
 
@@ -133,8 +140,8 @@ def interpret_state_as_bool(raw_state: Any, key: str = "") -> bool | None:
         status_code, _status_text = parse_composite_state(state_str)
         state_int = convert_to_int(status_code)
         if state_int is not None:
-            if state_int in STATE_MAP:
-                return STATE_MAP[state_int]
+            if state_int in state_map:
+                return state_map[state_int]
             return state_int != 0
 
     # Fast boolean string checks using pre-compiled patterns
@@ -147,8 +154,9 @@ def interpret_state_as_bool(raw_state: Any, key: str = "") -> bool | None:
     if NUMERIC_PATTERN.match(state_str):
         return int(state_str) != 0
 
-    # Default: non-empty/valid numeric = True
-    return bool(raw_state) and raw_state != ""
+    # Unrecognized strings (e.g. "STOPPED", "MAINTENANCE") must not be
+    # guessed as ON - report unknown instead
+    return None
 
 
 # =============================================================================

--- a/custom_components/violet_pool_controller/number.py
+++ b/custom_components/violet_pool_controller/number.py
@@ -92,13 +92,15 @@ class VioletNumber(VioletPoolControllerEntity, NumberEntity):
             return self._optimistic_value
 
         # Special case: pump speed — determine active level from PUMP_RPM_{i}
-        # PUMP_RPM_{i} returns status codes (0-6); values 1,2,3,4 = output ON
+        # PUMP_RPM_{i} returns status codes (0-6); 1, 3 and 4 mean output ON
+        # (2 = rule-blocked OFF). PUMP_RPM_0 is the PUMP_STOP output and lies
+        # below this entity's min value of 1, so start at level 1.
         if self._api_key == "PUMP_SPEED":
-            for level in range(4):  # levels 0-3 (PUMP_RPM_0 to PUMP_RPM_3)
+            for level in range(1, 4):  # levels 1-3 (PUMP_RPM_1 to PUMP_RPM_3)
                 rpm_val = self.get_value(f"PUMP_RPM_{level}")
                 if rpm_val is not None:
                     try:
-                        if int(rpm_val) in (1, 2, 3, 4):  # status code = ON
+                        if int(rpm_val) in (1, 3, 4):  # status code = ON
                             _LOGGER.debug(
                                 "Pump speed active: level %d (PUMP_RPM_%d=%s)",
                                 level,

--- a/custom_components/violet_pool_controller/select.py
+++ b/custom_components/violet_pool_controller/select.py
@@ -160,8 +160,14 @@ class VioletSelect(VioletPoolControllerEntity, SelectEntity):
                     return MODE_AUTO if not self._is_binary else MODE_ON
                 return MODE_AUTO if not self._is_binary else MODE_OFF
 
+            # PVSURPLUS uses its own scheme: 0 = off, 1/2 = on (not the
+            # 0-6 output states)
+            if self._device_key == "PVSURPLUS":
+                return MODE_ON if state_int in (1, 2) else MODE_OFF
+
             if self._is_binary:
-                return MODE_ON if state_int in (1, 2, 3, 4) else MODE_OFF
+                # Active states per DEVICE_STATE_MAPPING; 2 = rule-blocked OFF
+                return MODE_ON if state_int in (1, 3, 4) else MODE_OFF
 
             mode = STATE_TO_MODE.get(state_int)
             if mode:

--- a/custom_components/violet_pool_controller/sensor_modules/generic.py
+++ b/custom_components/violet_pool_controller/sensor_modules/generic.py
@@ -102,6 +102,9 @@ class VioletSensor(VioletPoolControllerEntity, SensorEntity):
         if is_timestamp_key and key not in _TIME_FORMAT_KEYS:
             try:
                 timestamp = float(raw_value)
+                # 0 means "never" / "no timer running" - not 1970-01-01
+                if timestamp == 0:
+                    return None
                 # Handle milliseconds: if timestamp > 10000000000, it's in milliseconds
                 # (10000000000 ms = September 2001, in seconds since 1970)
                 if timestamp > 10000000000:

--- a/custom_components/violet_pool_controller/service_control.py
+++ b/custom_components/violet_pool_controller/service_control.py
@@ -171,13 +171,13 @@ class VioletControlServiceHandlers:
                     _LOGGER.info("Dosing %s set to AUTO (enabled)", dosing_type)
 
                 elif action == "stop":
-                    api_dosing_type = DOSING_API_MAPPING.get(
-                        dosing_type, dosing_type
+                    # DOS_* OFF is routed through /triggerManualDosing as
+                    # DOSSTOP - stops a running manual dose without
+                    # persistently disabling the channel in the config
+                    result = await coordinator.device.api.set_switch_state(
+                        key=device_key, action=ACTION_OFF
                     )
-                    result = await coordinator.device.api.set_dosage_enabled(
-                        api_dosing_type, enabled=False
-                    )
-                    _LOGGER.info("Dosing %s stopped (disabled)", dosing_type)
+                    _LOGGER.info("Dosing %s stopped (DOSSTOP)", dosing_type)
 
                 if result.get("success") is not True:
                     _LOGGER.warning(

--- a/custom_components/violet_pool_controller/service_schemas.py
+++ b/custom_components/violet_pool_controller/service_schemas.py
@@ -19,41 +19,57 @@ from .service_helpers import (
 def get_service_schemas() -> dict[str, vol.Schema]:
     """Get all service schemas."""
     return {
-        "control_pump": vol.Schema(
-            {
-                vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                vol.Required("action"): vol.In(
-                    ["speed_control", "force_off", "eco_mode", "boost_mode", "auto"]
-                ),
-                vol.Optional("speed", default=2): vol.All(
-                    vol.Coerce(int), vol.Range(min=MIN_PUMP_SPEED, max=MAX_PUMP_SPEED)
-                ),
-                vol.Optional("duration", default=0): vol.All(
-                    vol.Coerce(int), vol.Range(min=0, max=86400)
-                ),
-            }
-        ),
-        "smart_dosing": vol.Schema(
-            {
-                vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                vol.Required("dosing_type"): vol.In(list(DOSING_TYPE_MAPPING.keys())),
-                vol.Required("action"): vol.In(["manual_dose", "auto", "stop"]),
-                vol.Optional("duration", default=30): vol.All(
-                    vol.Coerce(int),
-                    vol.Range(min=MIN_DOSING_DURATION, max=MAX_DOSING_DURATION),
-                ),
-                vol.Optional("safety_override", default=False): cv.boolean,
-            }
-        ),
-        "manage_pv_surplus": vol.Schema(
-            {
-                vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                vol.Required("mode"): vol.In(["activate", "deactivate", "auto"]),
-                vol.Optional("pump_speed", default=2): vol.All(
-                    vol.Coerce(int), vol.Range(min=MIN_PUMP_SPEED, max=MAX_PUMP_SPEED)
-                ),
-            }
-        ),
+        "control_pump": vol.Schema(vol.All(
+            vol.Schema(
+                {
+                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                    vol.Optional(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
+                    vol.Required("action"): vol.In(
+                        ["speed_control", "force_off", "eco_mode", "boost_mode", "auto"]
+                    ),
+                    vol.Optional("speed", default=2): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_PUMP_SPEED, max=MAX_PUMP_SPEED),
+                    ),
+                    vol.Optional("duration", default=0): vol.All(
+                        vol.Coerce(int), vol.Range(min=0, max=86400)
+                    ),
+                }
+            ),
+            cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+        )),
+        "smart_dosing": vol.Schema(vol.All(
+            vol.Schema(
+                {
+                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                    vol.Optional(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
+                    vol.Required("dosing_type"): vol.In(
+                        list(DOSING_TYPE_MAPPING.keys())
+                    ),
+                    vol.Required("action"): vol.In(["manual_dose", "auto", "stop"]),
+                    vol.Optional("duration", default=30): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_DOSING_DURATION, max=MAX_DOSING_DURATION),
+                    ),
+                    vol.Optional("safety_override", default=False): cv.boolean,
+                }
+            ),
+            cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+        )),
+        "manage_pv_surplus": vol.Schema(vol.All(
+            vol.Schema(
+                {
+                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                    vol.Optional(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
+                    vol.Required("mode"): vol.In(["activate", "deactivate", "auto"]),
+                    vol.Optional("pump_speed", default=2): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_PUMP_SPEED, max=MAX_PUMP_SPEED),
+                    ),
+                }
+            ),
+            cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+        )),
         "control_dmx_scenes": vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
@@ -65,28 +81,37 @@ def get_service_schemas() -> dict[str, vol.Schema]:
                 ),
             }
         ),
-        "set_light_color_pulse": vol.Schema(
-            {
-                vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                vol.Optional("pulse_count", default=1): vol.All(
-                    vol.Coerce(int), vol.Range(min=1, max=10)
-                ),
-                vol.Optional("pulse_interval", default=500): vol.All(
-                    vol.Coerce(int), vol.Range(min=100, max=2000)
-                ),
-            }
-        ),
+        "set_light_color_pulse": vol.Schema(vol.All(
+            vol.Schema(
+                {
+                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                    vol.Optional(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
+                    vol.Optional("pulse_count", default=1): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=10)
+                    ),
+                    vol.Optional("pulse_interval", default=500): vol.All(
+                        vol.Coerce(int), vol.Range(min=100, max=2000)
+                    ),
+                }
+            ),
+            cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+        )),
         "manage_digital_rules": vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
-                vol.Required("rule_key"): vol.In([f"DIRULE_{i}" for i in range(1, 9)]),
+                # Controller exposes DIRULE_1..7 only
+                vol.Required("rule_key"): vol.In([f"DIRULE_{i}" for i in range(1, 8)]),
                 vol.Required("action"): vol.In(["trigger", "lock", "unlock"]),
             }
         ),
         "test_output": vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): DEVICE_ID_SELECTOR,
-                vol.Required("output"): cv.string,
+                # Output keys are plain identifiers (e.g. PUMP, EXT1_1); the
+                # API builds the query string without URL-encoding this value
+                vol.Required("output"): vol.All(
+                    cv.string, vol.Match(r"^[A-Za-z0-9_]+$")
+                ),
                 vol.Optional("mode", default="SWITCH"): vol.In(["SWITCH", "ON", "OFF"]),
                 vol.Optional("duration", default=120): vol.All(
                     vol.Coerce(int), vol.Range(min=1, max=900)

--- a/custom_components/violet_pool_controller/services.yaml
+++ b/custom_components/violet_pool_controller/services.yaml
@@ -247,6 +247,26 @@ export_diagnostic_logs:
       default: true
       selector:
         boolean:
+    include_config:
+      description: Include integration configuration in the export
+      default: true
+      selector:
+        boolean:
+    include_history:
+      description: Include poll/error history in the export
+      default: true
+      selector:
+        boolean:
+    include_states:
+      description: Include current entity states in the export
+      default: true
+      selector:
+        boolean:
+    include_raw_data:
+      description: Include raw controller data in the export
+      default: true
+      selector:
+        boolean:
     save_to_file:
       description: Save logs to file in /config/ directory
       default: false

--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -453,7 +453,13 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
         try:
             _LOGGER.info("Setting switch %s to %s", key, action)
 
-            if key == "PUMP" and action == ACTION_ON:
+            if key.startswith("DIRULE_"):
+                # Rules are lock-controlled: ON = unlock, OFF = lock.
+                # Plain ON/OFF actions are not valid for DIRULE keys.
+                result = await self.device.api.set_digital_input_rule_lock(
+                    rule_key=key, locked=action == ACTION_OFF
+                )
+            elif key == "PUMP" and action == ACTION_ON:
                 speed = self._validate_speed(kwargs.get("speed", 2))
                 duration = self._validate_duration(kwargs.get("duration", 0))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,8 @@ ruff>=0.15.16
 mypy>=2.1.0
 pytest>=9.0.3
 pytest-cov>=7.1.0
-pytest-asyncio>=1.4.0
+# pytest-homeassistant-custom-component pins pytest-asyncio==1.3.0
+pytest-asyncio>=1.3.0
 # IMPORTANT: Always use latest version from https://github.com/MatthewFlamm/pytest-homeassistant-custom-component
 # Check for updates when new HA or Python versions are released
 pytest-homeassistant-custom-component>=0.13.337

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # requirements.txt
 # Tested against Home Assistant 2026.5.x (Python 3.14)
 homeassistant>=2026.5.0
-aiohttp>=3.14.1
+# HA 2026.5/2026.6 pins aiohttp==3.13.5; a higher floor makes the set unresolvable
+aiohttp>=3.13.5,<3.14
 voluptuous>=0.15.2
 violet-poolController-api>=0.0.25

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 import threading
@@ -151,6 +152,18 @@ def _create_mock_violet_api_module():
     const_api_module.API_PRIORITY_CRITICAL = 1
     const_api_module.API_PRIORITY_HIGH = 2
     const_api_module.API_PRIORITY_NORMAL = 3
+    # Action constants (mirror violet_poolcontroller_api.const_api)
+    const_api_module.ACTION_ON = "ON"
+    const_api_module.ACTION_OFF = "OFF"
+    const_api_module.ACTION_AUTO = "AUTO"
+    const_api_module.ACTION_PUSH = "PUSH"
+    const_api_module.ACTION_MAN = "MAN"
+    const_api_module.ACTION_COLOR = "COLOR"
+    const_api_module.ACTION_ALLON = "ALLON"
+    const_api_module.ACTION_ALLOFF = "ALLOFF"
+    const_api_module.ACTION_ALLAUTO = "ALLAUTO"
+    const_api_module.ACTION_LOCK = "LOCK"
+    const_api_module.ACTION_UNLOCK = "UNLOCK"
     mock_module.const_api = const_api_module
 
     # const_devices submodule
@@ -186,6 +199,19 @@ def _create_mock_violet_api_module():
         "CLOSED": "closed",
         "CLOSING": "closing",
         "STOPPED": "stopped",
+    }
+    const_devices_module.COVER_FUNCTIONS = {
+        "OPEN": "COVER_OPEN",
+        "CLOSE": "COVER_CLOSE",
+        "STOP": "COVER_STOP",
+    }
+    # Boolean state map (mirror violet_poolcontroller_api.const_devices):
+    # 2 = Auto - Priority OFF (Rule Blocked) is OFF
+    const_devices_module.STATE_MAP = {
+        0: False, 1: True, 2: False, 3: True, 4: True, 5: False, 6: False,
+        "0": False, "1": True, "2": False, "3": True, "4": True,
+        "5": False, "6": False,
+        "ON": True, "OFF": False, "AUTO": False,
     }
     const_devices_module.DEVICE_PARAMETERS = {}
     for _mod in ("EXT1", "EXT2"):
@@ -256,7 +282,12 @@ def _create_mock_violet_api_module():
     return mock_module
 
 
-if 'violet_poolcontroller_api' not in sys.modules:
+# Stub the external API package only when it is not actually installed -
+# shadowing the real package would test against mock behavior
+if (
+    'violet_poolcontroller_api' not in sys.modules
+    and importlib.util.find_spec('violet_poolcontroller_api') is None
+):
     mock_api = _create_mock_violet_api_module()
     sys.modules['violet_poolcontroller_api'] = mock_api
     sys.modules['violet_poolcontroller_api.api'] = mock_api.api
@@ -365,28 +396,7 @@ def pytest_fixture_setup(fixturedef, request):
             pass
 
 
-@pytest.fixture
-async def hass():
-    """Fixture that provides a Home Assistant instance."""
-    from homeassistant.core import HomeAssistant
-
-    ha = HomeAssistant()
-    ha.data = {}
-    return ha
-
-
-@pytest.fixture
-def device_registry(hass):
-    """Fixture that provides a device registry."""
-    from homeassistant.helpers.device_registry import DeviceRegistry
-
-    return DeviceRegistry()
-
-
-@pytest.fixture
-def entity_registry(hass):
-    """Fixture that provides an entity registry."""
-    class EntityRegistry:
-        pass
-
-    return EntityRegistry()
+# NOTE: The hass / device_registry / entity_registry fixtures are provided by
+# pytest-homeassistant-custom-component. Do not redefine them here - a local
+# override shadows the real fixtures and breaks every test that depends on a
+# functioning HomeAssistant instance.

--- a/tests/conftest_ha_mock.py
+++ b/tests/conftest_ha_mock.py
@@ -1,5 +1,12 @@
-"""Minimal Home Assistant mocks for tests without full HA installation."""
+"""Minimal Home Assistant mocks for tests without full HA installation.
 
+The mocks are only installed when the real packages are not importable.
+Replacing an installed Home Assistant with these stubs breaks
+pytest-homeassistant-custom-component (its fixtures patch real HA modules
+such as homeassistant.util.logging) and with it the entire test suite.
+"""
+
+import importlib.util
 import sys
 import types
 
@@ -436,12 +443,19 @@ def setup_homeassistant_mocks():
     sys.modules['homeassistant.helpers'] = ha_module.helpers
 
 
-# Setup mocks
-setup_homeassistant_mocks()
+# Setup mocks only when the real Home Assistant is not installed
+if (
+    'homeassistant' not in sys.modules
+    and importlib.util.find_spec('homeassistant') is None
+):
+    setup_homeassistant_mocks()
 
 
 # Setup pytest_homeassistant_custom_component mocks
-if 'pytest_homeassistant_custom_component' not in sys.modules:
+if (
+    'pytest_homeassistant_custom_component' not in sys.modules
+    and importlib.util.find_spec('pytest_homeassistant_custom_component') is None
+):
     common_module = types.ModuleType('pytest_homeassistant_custom_component')
     common_submodule = types.ModuleType('common')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,25 +154,26 @@ class TestVioletPoolAPI:
             with pytest.raises(VioletPoolAPIError, match="Invalid JSON"):
                 await api._request("/test", expect_json=True)
 
-    async def test_set_all_dmx_scenes_handles_errors(self, api: VioletPoolAPI) -> None:
-        """Test that set_all_dmx_scenes continues after an error on one scene."""
+    async def test_set_all_dmx_scenes_sends_single_global_command(
+        self, api: VioletPoolAPI
+    ) -> None:
+        """ALLON/ALLOFF/ALLAUTO are global: one request switches all scenes."""
         with patch.object(
             api, "set_switch_state", new_callable=AsyncMock
         ) as mock_set_switch_state:
-
-            async def side_effect(key: str, action: str):
-                if key == "DMX_SCENE3":
-                    raise VioletPoolAPIError("Controller unavailable for scene 3")
-                return {"success": True, "response": f"{key} OK"}
-
-            mock_set_switch_state.side_effect = side_effect
+            mock_set_switch_state.return_value = {
+                "success": True,
+                "response": "DMX_SCENE1 OK",
+            }
 
             result = await api.set_all_dmx_scenes("ALLON")
 
-            assert mock_set_switch_state.call_count == 12
+            mock_set_switch_state.assert_awaited_once_with("DMX_SCENE1", "ALLON")
+            assert result["success"] is True
 
-            assert result["success"] is False
-
-            assert "Controller unavailable for scene 3" in result["response"]
-            assert "DMX_SCENE1 OK" in result["response"]
-            assert "DMX_SCENE12 OK" in result["response"]
+    async def test_set_all_dmx_scenes_rejects_unknown_action(
+        self, api: VioletPoolAPI
+    ) -> None:
+        """Unsupported DMX actions must raise instead of hitting the API."""
+        with pytest.raises(VioletPoolAPIError, match="Unsupported DMX action"):
+            await api.set_all_dmx_scenes("EXPLODE")

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -162,6 +162,6 @@ class TestVioletCover:
         mock_coordinator.data = None
         cover = VioletCover(mock_coordinator, config_entry)
 
-        # Should return False, not crash
+        # Unknown state: is_open False, is_closed None (HA semantics)
         assert cover.is_open is False
-        assert cover.is_closed is False
+        assert cover.is_closed is None

--- a/tests/test_dosing_use_flag.py
+++ b/tests/test_dosing_use_flag.py
@@ -24,23 +24,27 @@ class TestDosingUseFlagPureFunction:
 
     # --- _USE = "1" → normal STATE_MAP logic ---
 
-    def test_use_one_state_2_is_on(self):
-        """Chlor channel: state=2, _USE=1 → ON (from STATE_MAP)."""
-        assert _dosing_switch_on(2, "1") is True
+    def test_use_one_state_2_is_off(self):
+        """Chlor channel: state=2 (Auto - Priority OFF, rule blocked) → OFF."""
+        assert _dosing_switch_on(2, "1") is False
+
+    def test_use_one_state_1_is_on(self):
+        """state=1 (Auto - Active), _USE=1 → ON."""
+        assert _dosing_switch_on(1, "1") is True
 
     def test_use_one_state_0_is_off(self):
-        """pH- channel: state=0 (AUTO_OFF), _USE=1 → OFF."""
+        """pH- channel: state=0 (Auto - Standby), _USE=1 → OFF."""
         assert _dosing_switch_on(0, "1") is False
 
     def test_use_one_state_4_is_on(self):
-        """state=4 (MANUAL_ON_FORCED), _USE=1 → ON."""
+        """state=4 (Manual ON, forced), _USE=1 → ON."""
         assert _dosing_switch_on(4, "1") is True
 
     # --- _USE absent (None) → normal STATE_MAP logic ---
 
     def test_no_use_key_state_2_falls_back_to_state_map(self):
-        """No _USE key: state=2 → True per STATE_MAP."""
-        assert _dosing_switch_on(2, None) is True
+        """No _USE key: state=2 (Auto - Priority OFF, rule blocked) → False."""
+        assert _dosing_switch_on(2, None) is False
 
     def test_no_use_key_state_0_is_off(self):
         """No _USE key: state=0 → False per STATE_MAP."""
@@ -61,9 +65,9 @@ class TestDosingUseFlagPureFunction:
         assert _dosing_switch_on(2, "0") is False
 
     def test_chlor_in_use(self):
-        """DOS_1_CL: state=2, USE='1' (Chlor active) → ON."""
-        assert _dosing_switch_on(2, "1") is True
+        """DOS_1_CL: state=1 (Auto - Active), USE='1' (Chlor active) → ON."""
+        assert _dosing_switch_on(1, "1") is True
 
     def test_phm_in_use(self):
-        """DOS_4_PHM: state=2, USE='1' (pH- active) → ON."""
-        assert _dosing_switch_on(2, "1") is True
+        """DOS_4_PHM: state=1 (Auto - Active), USE='1' (pH- active) → ON."""
+        assert _dosing_switch_on(1, "1") is True

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -21,7 +21,8 @@ from custom_components.violet_pool_controller.entity import interpret_state_as_b
     [
         ("3|PUMP_ANTI_FREEZE", True),
         ("5|AUTO_WAIT", False),
-        (" 2 |AUTO", True),
+        # State 2 = "Auto - Priority OFF (Rule Blocked)" → device is OFF
+        (" 2 |AUTO", False),
         ("0|OFF", False),
         ("N/A", None),
         ("n/a", None),
@@ -29,11 +30,32 @@ from custom_components.violet_pool_controller.entity import interpret_state_as_b
         ("unknown", None),
         ("NONE", None),
         ("NULL", None),
+        ("---", None),
         (None, None),
-        ("", False),
+        ("", None),
     ],
 )
 def test_interpret_state_with_numeric_prefix(raw_state, expected):
     """Composite string states should use their numeric prefix for evaluation."""
 
     assert interpret_state_as_bool(raw_state, "PUMPSTATE") is expected
+
+
+@pytest.mark.parametrize(
+    "raw_state,expected",
+    [
+        (0, False),
+        (1, True),  # ON via digital input
+        (2, True),  # ON via HTTP request (not "rule blocked" like outputs)
+    ],
+)
+def test_interpret_pv_surplus_states(raw_state, expected):
+    """PVSURPLUS uses its own 0/1/2 scheme, not the 0-6 output states."""
+
+    assert interpret_state_as_bool(raw_state, "PVSURPLUS") is expected
+
+
+def test_unrecognized_string_is_unknown():
+    """Unknown strings must not be guessed as ON."""
+
+    assert interpret_state_as_bool("MAINTENANCE", "PUMP") is None

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -107,9 +107,9 @@ class TestCoverErrorHandling:
         """Test cover handles None data gracefully."""
         cover = VioletCover(mock_coordinator_error, config_entry)
 
-        # Should not crash, return safe defaults
+        # Should not crash; unknown state reports is_closed None
         assert cover.is_open is False
-        assert cover.is_closed is False
+        assert cover.is_closed is None
         assert cover.is_opening is False
         assert cover.is_closing is False
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -33,7 +33,7 @@ class TestSecurityFixes:
         api = VioletPoolAPI.__new__(VioletPoolAPI)
 
         # Test valid host
-        valid_url = api._build_secure_base_url("192.168.1.100", True)
+        valid_url = api._build_secure_base_url("192.168.1.100", use_ssl=True)
         assert valid_url.startswith("https://192.168.1.100")
 
         # Test SSRF attempts - should raise ValueError
@@ -45,10 +45,10 @@ class TestSecurityFixes:
         #     api._build_secure_base_url("169.254.169.254", True)
 
         with pytest.raises(ValueError, match="Invalid hostname"):
-            api._build_secure_base_url("../../../etc/passwd", True)
+            api._build_secure_base_url("../../../etc/passwd", use_ssl=True)
 
         with pytest.raises(ValueError, match="Invalid hostname"):
-            api._build_secure_base_url("', DROP TABLE users; --", True)
+            api._build_secure_base_url("', DROP TABLE users; --", use_ssl=True)
 
     def test_input_sanitization_config(self):
         """Test configuration input sanitization."""
@@ -109,11 +109,11 @@ class TestSecurityFixes:
         api = VioletPoolAPI.__new__(VioletPoolAPI)
         
         # SSL enabled
-        ssl_url = api._build_secure_base_url("example.com", True)
+        ssl_url = api._build_secure_base_url("example.com", use_ssl=True)
         assert ssl_url.startswith("https://")
         
         # SSL disabled
-        http_url = api._build_secure_base_url("example.com", False)
+        http_url = api._build_secure_base_url("example.com", use_ssl=False)
         assert http_url.startswith("http://")
 
     async def test_config_with_sanitization(self, api):
@@ -137,7 +137,7 @@ class TestSecurityFixes:
                 
                 # Get the sanitized config that was passed
                 call_args = mock_request.call_args
-                sanitized_config = call_args[1]['json_payload']
+                sanitized_config = call_args.kwargs['data']
                 
                 # Valid keys should be present
                 assert "valid_key" in sanitized_config
@@ -165,7 +165,7 @@ class TestSecurityFixes:
 
         for host in valid_hosts:
             try:
-                result = api._build_secure_base_url(host, True)
+                result = api._build_secure_base_url(host, use_ssl=True)
                 assert result is not None
                 assert result.startswith("https://")
             except ValueError:
@@ -187,4 +187,4 @@ class TestSecurityFixes:
 
         for host in invalid_hosts:
             with pytest.raises(ValueError):
-                api._build_secure_base_url(host, True)
+                api._build_secure_base_url(host, use_ssl=True)

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -172,12 +172,11 @@ class TestTranslationStructure:
         strings_data = load_strings_json()
         assert "services" in strings_data
 
-        # Required services
+        # Required services (must match services.yaml)
         required_services = [
-            "turn_auto",
-            "set_pv_surplus",
-            "set_temperature_target",
-            "set_ph_target",
+            "control_pump",
+            "smart_dosing",
+            "manage_pv_surplus",
             "export_diagnostic_logs",
         ]
 


### PR DESCRIPTION
## Audit: Verhalten der Integration vs. Original-Controller

Vollständiger Abgleich der Integration gegen das externe API-Paket `violet-poolController-api` 0.0.26 und die Controller-Spezifikation (`tests/getReadings_spec.json`). Dabei wurden mehrere echte Abweichungen vom Original-Controller sowie die Ursache der seit Wochen roten CI gefunden und behoben.

### Status-Interpretation (Kernfehler)

- **Status `2` („Auto – Priority OFF, Rule Blocked") wurde als EIN angezeigt** — laut Spec und `DEVICE_STATE_MAPPING` ist das Gerät dabei AUS. Betraf alle Switches, Binary Sensors und Dosierkanäle (`entity.py` STATE_MAP). Korrekt ist: EIN = {1, 3, 4}, AUS = {0, 2, 5, 6}.
- **PVSURPLUS** nutzt ein eigenes Schema (0 = aus, 1 = ein per Digitaleingang, 2 = ein per HTTP) und wird jetzt separat gemappt (entity, select).
- Unbekannte Status-Strings (`"---"`, `"STOPPED"`, …) werden nicht mehr als EIN geraten, sondern als unbekannt gemeldet.
- `select.py`/`number.py`: aktive Zustände auf (1, 3, 4) korrigiert; Pumpendrehzahl-Erkennung überspringt `PUMP_RPM_0` (= PUMP_STOP-Ausgang).
- Cover: unbekannter `COVER_STATE` meldet `is_closed = None` statt fälschlich „offen".

### Befehle an den Controller

- **DIRULE-Switches** senden jetzt LOCK/UNLOCK statt der für Regeln ungültigen ON/OFF-Aktionen; **DIRULE_8 entfernt** (Controller kennt nur Regeln 1–7).
- **`smart_dosing` „stop"** sendet jetzt DOSSTOP (stoppt die laufende Dosierung), statt den Kanal dauerhaft in der Controller-Konfiguration zu deaktivieren.
- `const.py` überschattete Paket-Konstanten mit lokalen Kopien — u. a. ein **leeres `DEVICE_PARAMETERS`-Dict**; die Schatten wurden entfernt.
- Solar-Klima-Entität erlaubt jetzt 40 °C (vorher hart auf 35 °C begrenzt, im Widerspruch zur Solar-Number-Entität); ORP-Sollwertbereich an den Sanitizer angeglichen (400–900 mV).
- Services akzeptieren `device_id`-Targets (vorher Schema-Fehler bei Geräte-/Bereichs-Auswahl in der UI); fehlende `export_diagnostic_logs`-Felder in `services.yaml` ergänzt; `test_output`-Output validiert.
- `device.py`: Repair-Issue wird bei wiederholtem Ausfall erneut erzeugt/gelöscht; optionaler getConfig-Abruf bricht den Poll nicht mehr ab; SSL-Default vereinheitlicht.
- Timestamp `0` („nie") wird als unbekannt statt 1970-01-01 angezeigt; Dosiermodul-CPU-Temperatur nutzt den korrekten (kleingeschriebenen) Spec-Key.

### CI/Test-Infrastruktur (CI auf `main` seit Ende Mai rot)

1. `tests/conftest_ha_mock.py` ersetzte **bedingungslos** das installierte Home Assistant durch Stubs → alle 259 Tests schlugen mit Collection-Errors fehl. Stubs greifen jetzt nur noch, wenn HA/das API-Paket nicht installiert sind.
2. `conftest.py` überschattete die `hass`-Fixture von pytest-homeassistant-custom-component mit einer inkompatiblen Minimal-Version — entfernt.
3. Dependency-Konflikte durch Dependabot-Bumps behoben: `aiohttp>=3.14.1` (HA pinnt `==3.13.5`) und `pytest-asyncio>=1.4.0` (phcc pinnt `==1.3.0`).
4. Veraltete Tests an das reale API-Verhalten angepasst (DMX-Globalbefehl, Sanitizer-Signaturen, Service-Namen).

### Verifikation

- **266 Tests bestehen** (Python 3.14.5, HA 2026.x, echtes API-Paket) — vorher: 0 bestanden / 259 Errors
- Ruff: 0 Fehler; mypy: keine neuen Fehler gegenüber Baseline

https://claude.ai/code/session_01RoMN95TrXvzrwM88KVEJF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoMN95TrXvzrwM88KVEJF4)_

## Summary by Sourcery

Align entity state handling and controller interactions with the official Violet Pool Controller API while repairing the Home Assistant/pytest test setup so the suite runs against the real integration.

New Features:
- Allow key services to target devices via device_id in addition to entity_id and validate test_output output keys.
- Expose additional diagnostic export toggles to include configuration, history, states, and raw controller data.

Bug Fixes:
- Correct boolean state mapping for multi-state devices so rule-blocked and unknown states are treated as off/unknown, including dedicated handling for PVSURPLUS and cover states.
- Fix smart dosing stop behavior to send a non-persistent stop command instead of disabling dosing channels in the controller configuration.
- Ensure DIRULE switches use lock/unlock semantics with the supported rule range and avoid invalid ON/OFF actions.
- Treat timestamp 0 as an unknown value instead of 1970-01-01 and fix the dosing module CPU temperature key to match the controller spec.
- Increase solar climate max temperature to 40°C and align ORP setpoint ranges with controller-side validation.

Enhancements:
- Reuse action and device-parameter constants directly from the external API package instead of local copies to stay in sync with the controller.
- Refine pump speed detection, binary/select state interpretation, and cover closed-state reporting to better reflect controller behavior.
- Improve device polling robustness by treating optional config reads as non-fatal, resetting recovery markers on new outages, and aligning SSL defaults with integration settings.
- Adjust documentation to describe the corrected state model, DMX scene range, and concurrency model of the integration.

Build:
- Align runtime dependency versions (notably aiohttp) with Home Assistant pinning to keep the environment resolvable.

Tests:
- Update and expand tests to cover corrected state semantics, PVSURPLUS handling, cover behavior, DMX global actions and validation, and configuration sanitization.
- Prevent local Home Assistant and fixture mocks from shadowing real packages/fixtures so the suite can run against an installed HA and API package.
- Relax dependency pins to match Home Assistant constraints and clean up test helpers so tests collect and pass under current environments.