### PR TITLE
fix: Simplify feature-release workflow - use gh CLI directly

### DIFF
--- a/.github/workflows/feature-release.yml
+++ b/.github/workflows/feature-release.yml
@@ -44,57 +44,41 @@ jobs:
       - name: Create feature release tag
         id: tag
         run: |
-          TIMESTAMP=$(date +%s)
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           TAG="v${{ steps.version.outputs.version_clean }}-feature-${{ steps.feature.outputs.name }}-${COMMIT_SHORT}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Generate release notes
-        id: notes
-        run: |
-          COMMIT_SHORT=$(git rev-parse --short HEAD)
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-
-          NOTES="# Feature Release: ${{ steps.feature.outputs.name }}
-
-**Branch:** \`${{ steps.feature.outputs.branch }}\`
-**Commit:** \`${COMMIT_SHORT}\`
-**Version Base:** \`${{ steps.version.outputs.version_clean }}\`
-
-## Latest Commit
-\`\`\`
-${COMMIT_MSG}
-\`\`\`
-
----
-
-⚠️ **Pre-Release Note:** This is a feature release from a development branch. Not marked as latest stable release.
-
-✅ All ruff checks pass
-📝 Code quality validated
-🔧 Ready for testing
-
-This release includes all changes from the feature branch and can be used for testing and validation before merging to main."
-
-          echo 'notes<<EOF' >> $GITHUB_OUTPUT
-          echo "${NOTES}" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "commit_short=${COMMIT_SHORT}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          release_name: "Feature: ${{ steps.feature.outputs.name }} (${{ steps.version.outputs.version_clean }})"
-          body: ${{ steps.notes.outputs.notes }}
-          draft: false
-          prerelease: true
+        run: |
+          COMMIT_SHORT="${{ steps.tag.outputs.commit_short }}"
+          NOTES="# Feature Release: ${{ steps.feature.outputs.name }}
 
-      - name: Comment on feature branch
+          **Branch:** \`${{ steps.feature.outputs.branch }}\`
+          **Commit:** \`${COMMIT_SHORT}\`
+          **Version Base:** \`${{ steps.version.outputs.version_clean }}\`
+
+          Changes from the feature branch ready for testing and validation before merging to main.
+
+          ⚠️ **Pre-Release Note:** This is a feature release from a development branch. Not marked as latest stable release.
+
+          ✅ All ruff checks pass
+          📝 Code quality validated
+          🔧 Ready for testing"
+
+          gh release create \
+            "${{ steps.tag.outputs.tag }}" \
+            --title "Feature: ${{ steps.feature.outputs.name }} (${{ steps.version.outputs.version_clean }})" \
+            --notes "${NOTES}" \
+            --prerelease
+
+      - name: Workflow Summary
         run: |
           echo "✅ Feature release created: ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📦 Release: [${{ steps.tag.outputs.tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.tag.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Branch: ${{ steps.feature.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${{ steps.feature.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ steps.tag.outputs.commit_short }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Replace multiline string handling with gh release create command:
- Eliminates complex Bash heredoc syntax that caused YAML parsing errors
- Uses GitHub CLI directly for cleaner, more reliable release creation
- Maintains same functionality (pre-release, tag generation, notes)
- Fixes line 60 YAML syntax error

## Summary by Sourcery

Simplify the feature-release GitHub Actions workflow by generating release notes inline and creating the release via the GitHub CLI instead of the create-release action.

Enhancements:
- Store the short commit hash in job outputs for reuse across steps, including in the release notes and workflow summary.
- Inline the release notes content in the workflow and pass it directly to the GitHub CLI, avoiding multiline output handling and YAML/heredoc complexity.
- Update the workflow summary step to include formatted branch and commit information for the created feature release.