### PR TITLE
feat: myviolet-hass learnings — API enums/exceptions/parsers + 6 HA integration improvements (v0.0.29)

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -61,6 +61,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.CLIMATE,
     Platform.COVER,
+    Platform.LIGHT,
     Platform.NUMBER,
     Platform.UPDATE,
 ]

--- a/custom_components/violet_pool_controller/climate.py
+++ b/custom_components/violet_pool_controller/climate.py
@@ -187,7 +187,13 @@ class VioletClimateEntity(VioletPoolControllerEntity, ClimateEntity):
 
     def _get_target_temperature(self) -> float:
         """Return the target temperature."""
-        # Check optimistic cache first
+        # Check coordinator setpoint cache first (populated immediately after writes)
+        possible_keys = _get_setpoint_fields_for_climate_type(self.climate_type)
+        for key in possible_keys:
+            if key in self.coordinator._setpoint_cache:
+                return self.coordinator._setpoint_cache[key]
+
+        # Fall back to per-entity optimistic cache (legacy)
         if self._optimistic_target_temp is not None:
             return self._optimistic_target_temp
 
@@ -335,6 +341,7 @@ class VioletClimateEntity(VioletPoolControllerEntity, ClimateEntity):
         if not self._validate_temperature(temperature):
             return
 
+        possible_keys = _get_setpoint_fields_for_climate_type(self.climate_type)
         try:
             _LOGGER.info(
                 "Setting %s temperature to %.1f°C",
@@ -349,17 +356,15 @@ class VioletClimateEntity(VioletPoolControllerEntity, ClimateEntity):
             if result.get("success") is True:
                 _LOGGER.debug("Temperature set successfully: %s", result)
 
+                # Update coordinator cache for immediate cross-entity propagation
+                for key in possible_keys:
+                    if self.coordinator.data is None or key in self.coordinator.data:
+                        self.coordinator.update_setpoint_cache(key, temperature)
+                        break
+
                 self._optimistic_target_temp = temperature
                 self._attr_target_temperature = temperature
                 self.async_write_ha_state()
-
-                _LOGGER.debug(
-                    (
-                        "Optimistic update: %.1f°C"
-                        " (local cache, coordinator.data not mutated)"
-                    ),
-                    temperature,
-                )
 
                 task = asyncio.create_task(self._delayed_refresh())
                 task.add_done_callback(self._handle_refresh_error)
@@ -533,13 +538,6 @@ async def async_setup_entry(
     entities = []
 
     _LOGGER.debug("Climate Setup - Active features: %s", active_features)
-
-    # Get hardware configuration for dynamic naming
-    hw_config = None
-    if coordinator.device:
-        hw_config = coordinator.device.hardware_config
-
-    name_resolver = EntityNameResolver(hw_config)
 
     if coordinator.data is not None:
         _LOGGER.debug("Coordinator data keys: %d", len(coordinator.data.keys()))

--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -632,8 +632,8 @@ class ConfigFlow(
             CONF_USE_SSL: ui.get(CONF_USE_SSL, DEFAULT_USE_SSL),
             CONF_DEVICE_NAME: ui.get(CONF_DEVICE_NAME, "🌊 Violet Pool Controller"),
             CONF_CONTROLLER_NAME: ui.get(CONF_CONTROLLER_NAME, DEFAULT_CONTROLLER_NAME),
-            CONF_USERNAME: ui.get(CONF_USERNAME, ""),
-            CONF_PASSWORD: ui.get(CONF_PASSWORD, ""),
+            CONF_USERNAME: ui.get(CONF_USERNAME) or None,
+            CONF_PASSWORD: ui.get(CONF_PASSWORD) or None,
             CONF_DEVICE_ID: int(ui.get(CONF_DEVICE_ID, 1)),
             CONF_POLLING_INTERVAL: int(
                 ui.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)

--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -397,16 +397,16 @@ for ext_bank in [1, 2]:
                 "entity_registry_enabled_default": False,
             }
         )
-# Dynamically add DMX scenes
+# DMX scenes are exposed as LightEntity (see light.py) instead of Switch
+DMX_LIGHTS: list[dict[str, str | bool | None]] = []
 for i in range(1, 13):
-    SWITCHES.append(
+    DMX_LIGHTS.append(
         {
             "key": f"DMX_SCENE{i}",
             "name": f"DMX Scene {i}",
             "translation_key": f"dmx_scene{i}",
             "icon": "mdi:lightbulb-multiple",
             "feature_id": "led_lighting",
-            "entity_category": EntityCategory.CONFIG,
             "entity_registry_enabled_default": False,
         }
     )

--- a/custom_components/violet_pool_controller/cover.py
+++ b/custom_components/violet_pool_controller/cover.py
@@ -21,12 +21,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from violet_poolcontroller_api.api import VioletPoolAPIError
+from violet_poolcontroller_api.api import VioletPoolAPIError, VioletUnsafeOperationError
 
 from .const import (
-    ACTION_PUSH,
     CONF_ACTIVE_FEATURES,
-    COVER_FUNCTIONS,
     COVER_STATE_MAP,
     DOMAIN,
 )
@@ -124,23 +122,16 @@ class VioletCover(VioletPoolControllerEntity, CoverEntity):
         Raises:
             HomeAssistantError: On API errors.
         """
-        cover_api_key = COVER_FUNCTIONS.get(action.upper())
-
-        if not cover_api_key:
-            _LOGGER.error("Invalid cover action: %s", action)
-            raise HomeAssistantError(
-                translation_key="invalid_action",
-                translation_domain=DOMAIN,
-                translation_placeholders={"action": action},
-            )
-
         self._last_action = action
 
         try:
             _LOGGER.debug("Sending cover command: %s", action)
 
-            result = await self.device.api.set_switch_state(
-                key=cover_api_key, action=ACTION_PUSH
+            # acknowledge_unsafe=True: HA only exposes cover controls to users
+            # who have explicitly enabled the cover feature in the config flow,
+            # so the safety acknowledgment is implicitly given at setup time.
+            result = await self.device.api.set_cover_command(
+                action, acknowledge_unsafe=True
             )
 
             if result.get("success") is True:
@@ -155,6 +146,14 @@ class VioletCover(VioletPoolControllerEntity, CoverEntity):
 
             # Refresh data after command
             await self.coordinator.async_request_refresh()
+
+        except VioletUnsafeOperationError as err:
+            _LOGGER.error("Cover command '%s' refused (unsafe): %s", action, err)
+            raise HomeAssistantError(
+                translation_key="api_error",
+                translation_domain=DOMAIN,
+                translation_placeholders={"detail": str(err)},
+            ) from err
 
         except VioletPoolAPIError as err:
             _LOGGER.error("API error for cover command '%s': %s", action, err)

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
@@ -26,7 +26,8 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from violet_poolcontroller_api.api import VioletPoolAPI, VioletPoolAPIError
+from violet_poolcontroller_api.api import VioletAuthError, VioletPoolAPI, VioletPoolAPIError
+from violet_poolcontroller_api.readings import VioletReadings
 
 from .config_entry_helpers import (
     extract_api_host,
@@ -317,9 +318,10 @@ class VioletPoolControllerDevice:
         which is reliable because the API filter only removes keys whose
         module is absent.
         """
-        data = await self.api.get_readings()
+        _readings = await self.api.get_readings()
+        data: dict[str, Any] = dict(_readings) if _readings is not None else {}
 
-        if isinstance(data, dict):
+        if data and isinstance(data, dict):
 
             def is_valid(val: Any) -> bool:
                 return val is not None and str(val).strip().upper() != "N/A"
@@ -593,6 +595,9 @@ class VioletPoolControllerDevice:
             # Already counted and logged where it was raised - the generic
             # handler below must not increment the failure counter again
             raise
+        except VioletAuthError:
+            # Auth errors must surface immediately so HA can trigger re-auth
+            raise
         except VioletPoolAPIError as err:
             self._last_error = str(err)
             self._consecutive_failures += 1
@@ -676,7 +681,7 @@ class VioletPoolControllerDevice:
             else "Violet Pool Controller"
         )
 
-        return {
+        info: dict[str, Any] = {
             "identifiers": {(DOMAIN, f"{self.api_url}_{self.device_id}")},
             # Uses controller_name for visual distinction in multi-controller setups
             "name": self.controller_name,
@@ -686,6 +691,12 @@ class VioletPoolControllerDevice:
             # Auto-area for multi-controller setups
             "suggested_area": self.controller_name,
         }
+        for _serial_key in ("SERIAL", "SERIAL_NUMBER", "serial", "serial_number", "HW_SERIAL"):
+            _serial_val = self._data.get(_serial_key)
+            if _serial_val:
+                info["serial_number"] = str(_serial_val)
+                break
+        return info
 
     @property
     def system_health(self) -> float:
@@ -821,7 +832,7 @@ class VioletPoolControllerDevice:
         return None
 
 
-class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator):
+class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator[VioletReadings]):
     """Data update coordinator for the Violet Pool Controller."""
 
     def __init__(
@@ -839,6 +850,7 @@ class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=polling_interval),
         )
         self.device = device
+        self._setpoint_cache: dict[str, float] = {}
 
         _LOGGER.info(
             "Coordinator initialized for '%s' (polling every %ds)",
@@ -846,19 +858,30 @@ class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator):
             polling_interval,
         )
 
-    async def _async_update_data(self) -> dict[str, Any]:
+    def update_setpoint_cache(self, key: str, value: float) -> None:
+        """Cache a setpoint write and immediately notify all listeners.
+
+        This lets entities show the new value without waiting for the next
+        poll cycle. The cache entry persists until the next successful poll
+        returns the key, at which point coordinator.data takes precedence.
+        """
+        self._setpoint_cache[key] = value
+        self.async_update_listeners()
+
+    async def _async_update_data(self) -> VioletReadings:
         """
         Update data from the device.
 
-        Returns a fresh dict from the device on every call so that
+        Returns a VioletReadings snapshot on every call so that
         HA's DataUpdateCoordinator always sees a new data object and
         triggers entity listener callbacks.
 
         Returns:
-            A dictionary containing the updated data.
+            A VioletReadings snapshot of the updated data.
 
         Raises:
-            UpdateFailed: If the update fails.
+            ConfigEntryAuthFailed: On HTTP 401/403 (triggers re-auth flow).
+            UpdateFailed: If the update fails for any other reason.
         """
         try:
             data = await self.device.async_update()
@@ -866,7 +889,11 @@ class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(
                     f"Empty data returned for '{self.device.device_name}'"
                 )
-            return data
+            return VioletReadings(data)
+        except ConfigEntryAuthFailed:
+            raise
+        except VioletAuthError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
         except UpdateFailed:
             raise
         except VioletPoolAPIError as err:

--- a/custom_components/violet_pool_controller/entity_names.py
+++ b/custom_components/violet_pool_controller/entity_names.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from .hardware_config import HardwareConfig
-
 
 class EntityNameResolver:
     """Resolve entity names from hardware configuration."""

--- a/custom_components/violet_pool_controller/light.py
+++ b/custom_components/violet_pool_controller/light.py
@@ -1,0 +1,150 @@
+# =============================================================================
+# Violet Pool Controller – Home Assistant Custom Integration
+# Copyright © 2026 Xerolux
+# Developed and created by Xerolux
+# https://github.com/Xerolux/violet-hass
+# =============================================================================
+
+"""Light platform for Violet Pool Controller (DMX scenes)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from homeassistant.components.light import ColorMode, LightEntity, LightEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from violet_poolcontroller_api.api import VioletPoolAPIError
+
+from .const import (
+    ACTION_OFF,
+    ACTION_ON,
+    CONF_ACTIVE_FEATURES,
+    DMX_LIGHTS,
+    DOMAIN,
+)
+from .device import VioletPoolDataUpdateCoordinator
+from .entity import VioletPoolControllerEntity
+from .entity_names import EntityNameResolver
+
+_LOGGER = logging.getLogger(__name__)
+
+# Coordinator-based platform; HA should not throttle entity state writes
+PARALLEL_UPDATES = 0
+
+# States where the DMX channel is active (matches DEVICE_STATE_MAPPING)
+_DMX_ON_STATES = {1, 3, 4}
+
+
+class VioletDmxLight(VioletPoolControllerEntity, LightEntity):
+    """DMX scene exposed as a simple on/off light entity."""
+
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    def __init__(
+        self,
+        coordinator: VioletPoolDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        description: LightEntityDescription,
+    ) -> None:
+        """Initialize the DMX light entity."""
+        super().__init__(coordinator, config_entry, description)
+        _LOGGER.debug("DMX light initialized: %s", description.key)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the DMX scene is active."""
+        raw = self.get_value(self.entity_description.key)
+        if raw is None:
+            return None
+        try:
+            return int(raw) in _DMX_ON_STATES
+        except (ValueError, TypeError):
+            return None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate the DMX scene."""
+        await self._send_dmx_command(ACTION_ON)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Deactivate the DMX scene."""
+        await self._send_dmx_command(ACTION_OFF)
+
+    async def _send_dmx_command(self, action: str) -> None:
+        """Send a command to the DMX scene channel."""
+        key = self.entity_description.key
+        try:
+            _LOGGER.debug("DMX command %s → %s", key, action)
+            result = await self.device.api.set_switch_state(key=key, action=action)
+            if result.get("success") is True:
+                _LOGGER.info("DMX %s %s succeeded", key, action)
+            else:
+                _LOGGER.warning("DMX %s %s: %s", key, action, result.get("response", result))
+            await self.coordinator.async_request_refresh()
+        except VioletPoolAPIError as err:
+            _LOGGER.error("API error for DMX %s %s: %s", key, action, err)
+            raise HomeAssistantError(
+                translation_key="api_error",
+                translation_domain=DOMAIN,
+                translation_placeholders={"detail": str(err)},
+            ) from err
+        except Exception as err:
+            _LOGGER.exception("Unexpected error for DMX %s %s: %s", key, action, err)
+            raise HomeAssistantError(
+                translation_key="unexpected_error",
+                translation_domain=DOMAIN,
+                translation_placeholders={"detail": str(err)},
+            ) from err
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up DMX light entities from a config entry."""
+    coordinator: VioletPoolDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    active_features = config_entry.options.get(
+        CONF_ACTIVE_FEATURES, config_entry.data.get(CONF_ACTIVE_FEATURES, [])
+    )
+
+    if "led_lighting" not in active_features:
+        _LOGGER.debug("LED lighting feature not enabled; skipping DMX lights")
+        return
+
+    if coordinator.data is None:
+        _LOGGER.warning("Coordinator data is None; skipping DMX light setup")
+        return
+
+    hw_config = coordinator.device.hardware_config if coordinator.device else None
+    name_resolver = EntityNameResolver(hw_config)
+
+    entities: list[LightEntity] = []
+    for light_config in DMX_LIGHTS:
+        key = cast(str, light_config["key"])
+        if key not in coordinator.data:
+            continue
+
+        entity_name = cast(str, light_config["name"])
+        resolved = name_resolver.resolve_entity_name("light", key, entity_name)
+        if resolved:
+            entity_name = resolved
+
+        description = LightEntityDescription(
+            key=key,
+            name=entity_name,
+            translation_key=cast(str | None, light_config.get("translation_key")),
+            icon=cast(str | None, light_config.get("icon")),
+        )
+        entities.append(VioletDmxLight(coordinator, config_entry, description))
+
+    if entities:
+        async_add_entities(entities)
+        _LOGGER.info("%d DMX light entities added for '%s'", len(entities), config_entry.title)

--- a/custom_components/violet_pool_controller/number.py
+++ b/custom_components/violet_pool_controller/number.py
@@ -28,7 +28,6 @@ from violet_poolcontroller_api.utils_sanitizer import InputSanitizer
 from .const import CONF_ACTIVE_FEATURES, DOMAIN, SETPOINT_DEFINITIONS
 from .device import VioletPoolDataUpdateCoordinator
 from .entity import VioletPoolControllerEntity
-from .entity_names import EntityNameResolver
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/violet_pool_controller/select.py
+++ b/custom_components/violet_pool_controller/select.py
@@ -30,7 +30,6 @@ from .const import (
 )
 from .device import VioletPoolDataUpdateCoordinator
 from .entity import VioletPoolControllerEntity
-from .entity_names import EntityNameResolver
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/violet_pool_controller/update_helper.py
+++ b/custom_components/violet_pool_controller/update_helper.py
@@ -7,9 +7,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import logging
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,29 @@ def _create_mock_violet_api_module():
     api_module = types.ModuleType('api')
     api_module.VioletPoolAPI = MockVioletPoolAPI
     api_module.VioletPoolAPIError = MockVioletPoolAPIError
+
+    class MockVioletAuthError(MockVioletPoolAPIError):
+        """Mock auth error."""
+
+    class MockVioletTimeoutError(MockVioletPoolAPIError):
+        """Mock timeout error."""
+
+    class MockVioletUnsafeOperationError(MockVioletPoolAPIError):
+        """Mock unsafe operation error."""
+
+    api_module.VioletAuthError = MockVioletAuthError
+    api_module.VioletTimeoutError = MockVioletTimeoutError
+    api_module.VioletUnsafeOperationError = MockVioletUnsafeOperationError
     mock_module.api = api_module
+
+    # readings submodule (VioletReadings as a simple dict-wrapper)
+    readings_module = types.ModuleType('readings')
+
+    class MockVioletReadings(dict):
+        """Minimal VioletReadings stand-in that behaves like a dict."""
+
+    readings_module.VioletReadings = MockVioletReadings
+    mock_module.readings = readings_module
 
     # const_api submodule
     const_api_module = types.ModuleType('const_api')
@@ -294,6 +316,7 @@ if (
     sys.modules['violet_poolcontroller_api.const_api'] = mock_api.const_api
     sys.modules['violet_poolcontroller_api.const_devices'] = mock_api.const_devices
     sys.modules['violet_poolcontroller_api.utils_sanitizer'] = mock_api.utils_sanitizer
+    sys.modules['violet_poolcontroller_api.readings'] = mock_api.readings
 
 # CRITICAL: Patch deprecated timezone BEFORE any imports
 # pytest-homeassistant-custom-component uses 'US/Pacific' which is deprecated

--- a/tests/conftest_ha_mock.py
+++ b/tests/conftest_ha_mock.py
@@ -51,8 +51,10 @@ def setup_homeassistant_mocks():
         SWITCH = 'switch'
         CLIMATE = 'climate'
         COVER = 'cover'
+        LIGHT = 'light'
         NUMBER = 'number'
         SELECT = 'select'
+        UPDATE = 'update'
 
     ha_module.const.Platform = Platform
     sys.modules['homeassistant.const'] = ha_module.const
@@ -144,8 +146,12 @@ def setup_homeassistant_mocks():
     class ConfigEntryNotReady(Exception):
         pass
 
+    class ConfigEntryAuthFailed(Exception):
+        pass
+
     ha_module.exceptions.HomeAssistantError = HomeAssistantError
     ha_module.exceptions.ConfigEntryNotReady = ConfigEntryNotReady
+    ha_module.exceptions.ConfigEntryAuthFailed = ConfigEntryAuthFailed
     sys.modules['homeassistant.exceptions'] = ha_module.exceptions
 
     # Mock helpers - make it a proper package
@@ -309,6 +315,10 @@ def setup_homeassistant_mocks():
             self.logger = logger
             self.name = name
             self.update_interval = update_interval
+
+        # Support generic subscript syntax: DataUpdateCoordinator[T]
+        def __class_getitem__(cls, item):
+            return cls
 
     class CoordinatorEntity:
         def __init__(self, coordinator):

--- a/violet_poolcontroller_api/pyproject.toml
+++ b/violet_poolcontroller_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "violet-poolController-api"
-version = "0.0.27"
+version = "0.0.28"
 authors = [
   { name="Basti (Xerolux)", email="git@xerolux.de" },
 ]

--- a/violet_poolcontroller_api/pyproject.toml
+++ b/violet_poolcontroller_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "violet-poolController-api"
-version = "0.0.28"
+version = "0.0.29"
 authors = [
   { name="Basti (Xerolux)", email="git@xerolux.de" },
 ]

--- a/violet_poolcontroller_api/violet_poolcontroller_api/__init__.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/__init__.py
@@ -16,7 +16,17 @@
 
 """Violet Pool Controller API client library."""
 
-from .api import VioletPoolAPI, VioletPoolAPIError
+from .api import (
+    SETPOINT_RANGES,
+    VioletAuthError,
+    VioletPayloadError,
+    VioletPoolAPI,
+    VioletPoolAPIError,
+    VioletSetpointError,
+    VioletTimeoutError,
+    VioletUnsafeOperationError,
+    validate_setpoint,
+)
 from .circuit_breaker import CircuitBreaker, CircuitBreakerOpenError
 from .const_api import (  # noqa: F401
     ACTION_ALLAUTO,
@@ -39,25 +49,67 @@ from .const_devices import (  # noqa: F401
     COVER_STATE_MAP,
     DEVICE_PARAMETERS,
     STATE_TRANSLATIONS,
+    CoverState,
+    DmxSceneState,
+    OnewireState,
+    OutputState,
+    PvSurplusState,
+    RuleState,
     VioletState,
     get_state_translation_language,
     set_state_translation_language,
+)
+from .parsers import (  # noqa: F401
+    parse_epoch_milliseconds,
+    parse_epoch_seconds,
+    parse_hms_string,
+    parse_optional_seconds,
+    parse_runtime_string,
+    parse_uptime_string,
 )
 from .utils_rate_limiter import RateLimiter, get_global_rate_limiter
 from .utils_sanitizer import InputSanitizer
 
 __all__ = [
+    # Core client
     "VioletPoolAPI",
+    # Exception hierarchy
     "VioletPoolAPIError",
+    "VioletAuthError",
+    "VioletTimeoutError",
+    "VioletPayloadError",
+    "VioletSetpointError",
+    "VioletUnsafeOperationError",
+    # Setpoint validation
+    "SETPOINT_RANGES",
+    "validate_setpoint",
+    # Circuit breaker
     "CircuitBreaker",
     "CircuitBreakerOpenError",
+    # Enums
+    "OutputState",
+    "DmxSceneState",
+    "RuleState",
+    "CoverState",
+    "OnewireState",
+    "PvSurplusState",
+    # State helpers
     "VioletState",
+    "STATE_TRANSLATIONS",
+    "get_state_translation_language",
+    "set_state_translation_language",
+    # Parsers
+    "parse_runtime_string",
+    "parse_hms_string",
+    "parse_uptime_string",
+    "parse_epoch_seconds",
+    "parse_epoch_milliseconds",
+    "parse_optional_seconds",
+    # Utilities
     "InputSanitizer",
     "RateLimiter",
     "get_global_rate_limiter",
-    "get_state_translation_language",
-    "set_state_translation_language",
-    "STATE_TRANSLATIONS",
+    # Action constants
     "ACTION_ALLAUTO",
     "ACTION_ALLOFF",
     "ACTION_ALLON",
@@ -68,9 +120,11 @@ __all__ = [
     "ACTION_ON",
     "ACTION_PUSH",
     "ACTION_UNLOCK",
+    # Device constants
     "COVER_FUNCTIONS",
     "COVER_STATE_MAP",
     "DEVICE_PARAMETERS",
+    # Error codes
     "ERROR_CODES",
     "ERROR_SEVERITY_ALARM",
     "ERROR_SEVERITY_INFO",

--- a/violet_poolcontroller_api/violet_poolcontroller_api/__init__.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/__init__.py
@@ -67,6 +67,7 @@ from .parsers import (  # noqa: F401
     parse_runtime_string,
     parse_uptime_string,
 )
+from .readings import VioletReadings
 from .utils_rate_limiter import RateLimiter, get_global_rate_limiter
 from .utils_sanitizer import InputSanitizer
 
@@ -98,6 +99,8 @@ __all__ = [
     "STATE_TRANSLATIONS",
     "get_state_translation_language",
     "set_state_translation_language",
+    # Typed readings snapshot
+    "VioletReadings",
     # Parsers
     "parse_runtime_string",
     "parse_hms_string",

--- a/violet_poolcontroller_api/violet_poolcontroller_api/api.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/api.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import re
 import ssl
 from typing import TYPE_CHECKING, Any, cast
@@ -68,7 +69,7 @@ from .const_api import (
     TARGET_ORP,
     TARGET_PH,
 )
-from .const_devices import DEVICE_PARAMETERS
+from .const_devices import COVER_FUNCTIONS, DEVICE_PARAMETERS
 from .utils_rate_limiter import get_global_rate_limiter
 from .utils_sanitizer import InputSanitizer
 
@@ -81,11 +82,61 @@ _MAX_HOSTNAME_LENGTH = 253
 _HTTP_SERVER_ERROR = 500
 _HTTP_CLIENT_ERROR = 400
 _HTTP_TOO_MANY_REQUESTS = 429
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
 _MIN_CALIB_HISTORY_PARTS = 3
+
+# Valid setpoint ranges for each configurable target key (inclusive bounds).
+# Values outside these ranges or non-finite values are rejected before the
+# HTTP call to avoid surprising controller behaviour.
+SETPOINT_RANGES: dict[str, tuple[float, float]] = {
+    TARGET_PH: (6.0, 8.0),
+    TARGET_ORP: (500.0, 900.0),
+    TARGET_MIN_CHLORINE: (0.0, 5.0),
+    "HEATER_set_temp": (5.0, 45.0),
+    "SOLAR_maxtemp": (5.0, 55.0),
+}
+
+
+# =============================================================================
+# Exception hierarchy
+# =============================================================================
 
 
 class VioletPoolAPIError(Exception):
-    """Raised when the Violet Pool Controller API returns an error."""
+    """Base exception for all Violet Pool Controller API errors.
+
+    Callers can catch this base class to handle any API failure, or use
+    the specific subclasses for more targeted error handling.
+    """
+
+
+class VioletAuthError(VioletPoolAPIError):
+    """Raised when the controller rejects credentials (HTTP 401 or 403)."""
+
+
+class VioletTimeoutError(VioletPoolAPIError):
+    """Raised when an HTTP request to the controller exceeds the timeout."""
+
+
+class VioletPayloadError(VioletPoolAPIError):
+    """Raised when the controller returns a malformed or unparseable response."""
+
+
+class VioletSetpointError(VioletPoolAPIError, ValueError):
+    """Raised when a setpoint value is outside its documented valid range.
+
+    Inherits from both ``VioletPoolAPIError`` and ``ValueError`` so callers
+    can catch it as either.
+    """
+
+
+class VioletUnsafeOperationError(VioletPoolAPIError):
+    """Raised for potentially dangerous operations without explicit acknowledgment.
+
+    Pass ``acknowledge_unsafe=True`` to the relevant method to confirm that
+    the caller is aware of the risk (e.g. motorised cover movement).
+    """
 
 
 class _DeterministicClientError(Exception):
@@ -96,8 +147,42 @@ class _DeterministicClientError(Exception):
     circuit breaker failure count: 4xx responses are deterministic
     (bad credentials, unknown endpoint) and must not open the breaker
     that protects against a down controller or network.  It is
-    translated to VioletPoolAPIError before reaching the caller.
+    translated to the appropriate VioletPoolAPIError subclass before
+    reaching the caller.
     """
+
+    def __init__(self, msg: str, *, is_auth: bool = False) -> None:
+        super().__init__(msg)
+        self.is_auth = is_auth
+
+
+def validate_setpoint(field: str, value: float) -> None:
+    """Validate a setpoint value against documented controller ranges.
+
+    Args:
+        field: The configuration key (e.g. ``"DOSAGE_phminus_setpoint"``).
+        value: The numeric value to validate.
+
+    Raises:
+        VioletSetpointError: If ``value`` is non-finite or outside the
+            documented valid range for ``field``.  Fields with no registered
+            range are accepted without range checking.
+    """
+    if not math.isfinite(value):
+        msg = f"Invalid setpoint for '{field}': {value!r} is not a finite number"
+        raise VioletSetpointError(msg)
+
+    bounds = SETPOINT_RANGES.get(field)
+    if bounds is None:
+        return  # No documented range — accept any finite value
+
+    lo, hi = bounds
+    if not lo <= value <= hi:
+        msg = (
+            f"Setpoint '{field}' value {value} is outside the valid range "
+            f"[{lo}, {hi}]"
+        )
+        raise VioletSetpointError(msg)
 
 
 class VioletPoolAPI:
@@ -339,7 +424,11 @@ class VioletPoolAPI:
                             # deterministic - fail fast instead of retrying.
                             body = await response.text()
                             msg = f"HTTP {response.status} for {endpoint}: {body.strip()}"
-                            raise _DeterministicClientError(msg)
+                            is_auth = response.status in (
+                                _HTTP_UNAUTHORIZED,
+                                _HTTP_FORBIDDEN,
+                            )
+                            raise _DeterministicClientError(msg, is_auth=is_auth)
 
                         if expect_json:
                             try:
@@ -350,13 +439,25 @@ class VioletPoolAPI:
                             ) as err:
                                 body = await response.text()
                                 msg = f"Invalid JSON payload for {endpoint}: {body.strip()}"
-                                raise VioletPoolAPIError(
-                                    msg,
-                                ) from err
+                                raise VioletPayloadError(msg) from err
 
                         return await response.text()
 
-                except (TimeoutError, aiohttp.ClientError) as err:
+                except (TimeoutError, aiohttp.ServerTimeoutError) as err:
+                    last_error = VioletTimeoutError(
+                        f"Request to {endpoint} timed out: {err}",
+                    )
+                    _LOGGER.debug(
+                        "Attempt %d for %s timed out: %s",
+                        attempt,
+                        endpoint,
+                        err,
+                    )
+                    if attempt == self._max_retries:
+                        raise last_error from None
+                    delay = min(2.0, 0.2 * (2 ** (attempt - 1)))
+                    await asyncio.sleep(delay)
+                except aiohttp.ClientError as err:
                     last_error = VioletPoolAPIError(
                         f"Error communicating with Violet controller: {err}",
                     )
@@ -378,6 +479,8 @@ class VioletPoolAPI:
         try:
             return await self._circuit_breaker.call(_execute_request)
         except _DeterministicClientError as err:
+            if err.is_auth:
+                raise VioletAuthError(str(err)) from err
             raise VioletPoolAPIError(str(err)) from err
         except CircuitBreakerOpenError as err:
             msg = "Circuit breaker is open due to repeated communication failures"
@@ -1164,6 +1267,45 @@ class VioletPoolAPI:
 
         return await self.set_switch_state("DMX_SCENE1", action)
 
+    async def set_cover_command(
+        self,
+        action: str,
+        *,
+        acknowledge_unsafe: bool = False,
+    ) -> dict[str, Any]:
+        """Send an open, close, or stop command to the pool cover.
+
+        Cover movement is a potentially hazardous operation (motorised cover,
+        risk of entrapment).  Callers must explicitly pass
+        ``acknowledge_unsafe=True`` to confirm they are aware of the risk and
+        have taken appropriate safety precautions.
+
+        Args:
+            action: ``"OPEN"``, ``"CLOSE"``, or ``"STOP"`` (case-insensitive).
+            acknowledge_unsafe: Must be ``True`` to allow the command.
+
+        Returns:
+            A dictionary with the command result.
+
+        Raises:
+            VioletUnsafeOperationError: If ``acknowledge_unsafe`` is ``False``.
+            VioletPoolAPIError: If ``action`` is not a known cover action.
+
+        """
+        if not acknowledge_unsafe:
+            msg = (
+                "Cover movement is a potentially unsafe operation. "
+                "Pass acknowledge_unsafe=True to confirm you are aware of the risk."
+            )
+            raise VioletUnsafeOperationError(msg)
+
+        cover_key = COVER_FUNCTIONS.get(action.strip().upper())
+        if not cover_key:
+            msg = f"Unknown cover action '{action}'. Valid: {list(COVER_FUNCTIONS)}"
+            raise VioletPoolAPIError(msg)
+
+        return await self.set_switch_state(cover_key, ACTION_PUSH)
+
     async def set_light_color_pulse(self) -> dict[str, Any]:
         """Trigger the color pulse animation for the pool light.
 
@@ -1215,10 +1357,14 @@ class VioletPoolAPI:
 
         Args:
             climate_key: The climate key (HEATER or SOLAR).
-            temperature: The target temperature.
+            temperature: The target temperature in °C.
 
         Returns:
             A dictionary with the command result.
+
+        Raises:
+            VioletSetpointError: If ``temperature`` is outside the valid range
+                (5–45 °C for heater, 5–55 °C for solar).
 
         """
         config_key = (
@@ -1230,40 +1376,59 @@ class VioletPoolAPI:
         """Update the pH setpoint.
 
         Args:
-            value: The new pH target value.
+            value: The new pH target value (valid range: 6.0–8.0).
 
         Returns:
             A dictionary with the command result.
 
+        Raises:
+            VioletSetpointError: If ``value`` is outside the valid range or
+                is not a finite number.
+
         """
+        validate_setpoint(TARGET_PH, float(value))
         return await self.set_target_value(TARGET_PH, float(value))
 
     async def set_orp_target(self, value: int) -> dict[str, Any]:
         """Update the ORP setpoint.
 
         Args:
-            value: The new ORP target value.
+            value: The new ORP target value in mV (valid range: 500–900).
 
         Returns:
             A dictionary with the command result.
 
+        Raises:
+            VioletSetpointError: If ``value`` is outside the valid range or
+                is not a finite number.
+
         """
+        validate_setpoint(TARGET_ORP, float(value))
         return await self.set_target_value(TARGET_ORP, int(value))
 
     async def set_min_chlorine_level(self, value: float) -> dict[str, Any]:
         """Update the minimum chlorine level.
 
         Args:
-            value: The new minimum chlorine level.
+            value: The new minimum chlorine level in mg/L (valid range: 0.0–5.0).
 
         Returns:
             A dictionary with the command result.
 
+        Raises:
+            VioletSetpointError: If ``value`` is outside the valid range or
+                is not a finite number.
+
         """
+        validate_setpoint(TARGET_MIN_CHLORINE, float(value))
         return await self.set_target_value(TARGET_MIN_CHLORINE, float(value))
 
     async def set_target_value(self, key: str, value: float) -> dict[str, Any]:
         """Send a generic target value update to the controller.
+
+        For known setpoint keys (see ``SETPOINT_RANGES``), validation is
+        performed automatically.  Call ``validate_setpoint()`` directly for
+        keys not covered by the convenience methods.
 
         Args:
             key: The target key.
@@ -1272,7 +1437,12 @@ class VioletPoolAPI:
         Returns:
             A dictionary with the command result.
 
+        Raises:
+            VioletSetpointError: If ``value`` is non-finite or outside a
+                known valid range for ``key``.
+
         """
+        validate_setpoint(key, float(value))
         return await self.set_config({key: value})
 
     async def set_dosing_parameters(

--- a/violet_poolcontroller_api/violet_poolcontroller_api/api.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/api.py
@@ -70,6 +70,7 @@ from .const_api import (
     TARGET_PH,
 )
 from .const_devices import COVER_FUNCTIONS, DEVICE_PARAMETERS
+from .readings import VioletReadings
 from .utils_rate_limiter import get_global_rate_limiter
 from .utils_sanitizer import InputSanitizer
 
@@ -717,11 +718,17 @@ class VioletPoolAPI:
             readings = {k: v for k, v in readings.items() if not k.startswith("EXT2")}
         return readings
 
-    async def get_readings(self) -> dict[str, Any]:
-        """Return the complete dataset from the controller.
+    async def get_readings(self) -> VioletReadings:
+        """Return the complete dataset from the controller as a typed snapshot.
+
+        The returned :class:`~violet_poolcontroller_api.readings.VioletReadings`
+        object implements :class:`~collections.abc.Mapping`, so all existing
+        code that accesses ``data.get("KEY")`` or ``"KEY" in data`` continues
+        to work unchanged.  Typed properties (``readings.pump``,
+        ``readings.ph``, etc.) are available as an additive convenience.
 
         Returns:
-            A dictionary containing all readings.
+            A :class:`VioletReadings` instance wrapping all readings.
 
         Raises:
             VioletPoolAPIError: If the payload is unexpected.
@@ -732,7 +739,8 @@ class VioletPoolAPI:
             query="ALL",
             payload_name="getReadings",
         )
-        return self._flatten_getreadings_response(response)
+        flat = self._flatten_getreadings_response(response)
+        return VioletReadings(flat)
 
     async def get_hardware_profile(self) -> dict[str, bool]:
         """Detect connected hardware modules from the controller readings.
@@ -750,28 +758,29 @@ class VioletPoolAPI:
             query="ALL",
             payload_name="getReadings",
         )
-        readings = self._flatten_getreadings_response(response)
+        # Use flat dict directly (VioletReadings wrapping not needed here)
+        flat = self._flatten_getreadings_response(response)
 
-        has_base = not self._dosing_standalone and bool(readings)
+        has_base = not self._dosing_standalone and bool(flat)
         return {
             "base_module": has_base,
             "dosing_module": self._dosing_standalone
-            or "SYSTEM_dosagemodule_alive_count" in readings,
-            "extension_module_1": "SYSTEM_ext1module_alive_count" in readings,
-            "extension_module_2": "SYSTEM_ext2module_alive_count" in readings,
+            or "SYSTEM_dosagemodule_alive_count" in flat,
+            "extension_module_1": "SYSTEM_ext1module_alive_count" in flat,
+            "extension_module_2": "SYSTEM_ext2module_alive_count" in flat,
         }
 
     async def get_specific_readings(
         self,
         categories: list[str] | tuple[str, ...],
-    ) -> dict[str, Any]:
-        """Return a reduced dataset for the provided categories.
+    ) -> VioletReadings:
+        """Return a reduced typed snapshot for the provided categories.
 
         Args:
             categories: A list or tuple of category strings to fetch.
 
         Returns:
-            A dictionary containing the requested readings.
+            A :class:`VioletReadings` instance for the requested categories.
 
         Raises:
             VioletPoolAPIError: If no categories are provided
@@ -788,7 +797,7 @@ class VioletPoolAPI:
             query=query,
             payload_name="getReadings",
         )
-        return self._flatten_getreadings_response(response)
+        return VioletReadings(self._flatten_getreadings_response(response))
 
     async def get_history(
         self,

--- a/violet_poolcontroller_api/violet_poolcontroller_api/const_devices.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/const_devices.py
@@ -26,7 +26,108 @@ throughout the integration.
 
 from __future__ import annotations
 
+from enum import IntEnum, StrEnum
 from typing import Any, cast
+
+# =============================================================================
+# TYPED ENUMERATIONS
+# =============================================================================
+
+
+class OutputState(IntEnum):
+    """Output state codes returned by getReadings (manual section 26.1).
+
+    These codes apply to ~30 outputs: pump, heater, solar, light, dosing
+    channels, extension relays, etc.  Use the ``is_on``, ``is_manual``, and
+    ``is_emergency`` properties instead of comparing raw integers.
+    """
+
+    AUTO_OFF = 0
+    AUTO_ON = 1
+    AUTO_PRIO_OFF = 2
+    AUTO_PRIO_ON = 3
+    MANUAL_ON = 4
+    EMERGENCY_OFF = 5
+    MANUAL_OFF = 6
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the output is currently active."""
+        return self in (OutputState.AUTO_ON, OutputState.AUTO_PRIO_ON, OutputState.MANUAL_ON)
+
+    @property
+    def is_manual(self) -> bool:
+        """Return True when the output is in manual (non-auto) mode."""
+        return self in (OutputState.MANUAL_ON, OutputState.MANUAL_OFF)
+
+    @property
+    def is_emergency(self) -> bool:
+        """Return True when an emergency rule is responsible for the state."""
+        return self in (OutputState.AUTO_PRIO_ON, OutputState.EMERGENCY_OFF)
+
+
+class DmxSceneState(IntEnum):
+    """Output state codes for DMX scenes (subset of OutputState values)."""
+
+    AUTO_OFF = 0
+    AUTO_ON = 1
+    MANUAL_ON = 4
+    MANUAL_OFF = 6
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the DMX scene is active."""
+        return self in (DmxSceneState.AUTO_ON, DmxSceneState.MANUAL_ON)
+
+
+class RuleState(IntEnum):
+    """State codes for digital-input switching rules (DIRULE_*)."""
+
+    INACTIVE = 0
+    ACTIVE = 1
+    BLOCKED_BY_RULE = 5
+    BLOCKED_MANUALLY = 6
+
+
+class CoverState(StrEnum):
+    """Pool cover motion states returned by the COVER_STATE reading."""
+
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    OPENING = "OPENING"
+    CLOSING = "CLOSING"
+    STOPPED = "STOPPED"
+
+
+class OnewireState(StrEnum):
+    """1-wire temperature sensor status values (OW*_state readings).
+
+    Note: The controller uses ``DATA_MISSMATCH`` (double-s) — preserved here
+    for exact string matching against the API response.
+    """
+
+    OK = "OK"
+    CRC_FAULT = "CRC_FAULT"
+    DATA_MISMATCH = "DATA_MISSMATCH"
+    NOT_CONNECTED = "NOT_CONNECTED"
+    NO_SENSOR_CONFIGURED = "NO_SENSOR_CONFIGURED"
+
+
+class PvSurplusState(IntEnum):
+    """PV surplus trigger source states returned by the PVSURPLUS reading.
+
+    Unlike other outputs, PVSURPLUS uses values 0/1/2 instead of the
+    standard 0-6 scheme (manual section 26.3).
+    """
+
+    OFF = 0
+    ON_BY_INPUT = 1
+    ON_BY_HTTP = 2
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when PV surplus mode is active (regardless of source)."""
+        return self in (PvSurplusState.ON_BY_INPUT, PvSurplusState.ON_BY_HTTP)
 
 # =============================================================================
 # COVER CONTROL FUNCTIONS

--- a/violet_poolcontroller_api/violet_poolcontroller_api/parsers.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/parsers.py
@@ -1,0 +1,185 @@
+# violet-poolController-api - API für Violet Pool Controller
+# Copyright (C) 2024-2026  Xerolux
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Parser utilities for Violet Pool Controller timestamp and duration formats.
+
+The controller returns timestamps and durations in several distinct text
+formats.  This module centralises the conversion logic so that higher-level
+consumers (Home Assistant integration, standalone scripts) can work with
+standard Python ``datetime`` and ``timedelta`` objects instead of raw strings.
+
+Supported formats
+-----------------
+* ``"04h 33m 12s"`` / ``"1d 04h 33m 12s"`` – runtime strings
+* ``"HH:MM:SS"`` – legacy colon-separated duration
+* ``"250d 11h 48m"`` – CPU uptime strings
+* Unix epoch seconds (int / float / str)
+* Unix epoch milliseconds (int / float / str)
+* Float seconds with ``"NONE"`` sentinel
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import UTC, datetime, timedelta
+
+# ---------------------------------------------------------------------------
+# Pre-compiled patterns
+# ---------------------------------------------------------------------------
+
+# Matches optional days, hours, minutes, seconds with single-letter labels.
+# Examples: "04h 33m 12s", "1d 04h 33m 12s", "2h", "45m 30s"
+_RE_RUNTIME = re.compile(
+    r"(?:(\d+)\s*d)?\s*(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?",
+    re.IGNORECASE,
+)
+
+# Matches "HH:MM:SS" exactly.
+_RE_HMS = re.compile(r"^(\d+):(\d+):(\d+)$")
+
+# Matches optional days and hours (no seconds) – typical CPU uptime format.
+# Example: "250d 11h 48m"
+_RE_UPTIME = re.compile(
+    r"(?:(\d+)\s*d)?\s*(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?",
+    re.IGNORECASE,
+)
+
+
+def parse_runtime_string(value: str) -> timedelta:
+    """Parse a runtime string like ``"04h 33m 12s"`` into a ``timedelta``.
+
+    Days are supported: ``"1d 04h 33m 12s"`` → ``timedelta(days=1, hours=4, …)``.
+    All components are optional; an empty or non-matching string returns
+    ``timedelta(0)``.
+
+    Args:
+        value: Raw runtime string from the controller.
+
+    Returns:
+        ``timedelta`` representing the duration.
+    """
+    m = _RE_RUNTIME.search(value.strip())
+    if not m:
+        return timedelta(0)
+    days, hours, minutes, seconds = (int(g) if g else 0 for g in m.groups())
+    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+def parse_hms_string(value: str) -> timedelta:
+    """Parse a legacy ``"HH:MM:SS"`` duration string into a ``timedelta``.
+
+    Args:
+        value: Duration string in colon-separated format.
+
+    Returns:
+        ``timedelta`` representing the duration, or ``timedelta(0)`` if the
+        string does not match the expected format.
+    """
+    m = _RE_HMS.match(value.strip())
+    if not m:
+        return timedelta(0)
+    hours, minutes, seconds = (int(g) for g in m.groups())
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+def parse_uptime_string(value: str) -> timedelta:
+    """Parse a CPU uptime string like ``"250d 11h 48m"`` into a ``timedelta``.
+
+    Unlike :func:`parse_runtime_string`, seconds are not expected in this
+    format.  An empty or non-matching string returns ``timedelta(0)``.
+
+    Args:
+        value: Raw uptime string from the controller.
+
+    Returns:
+        ``timedelta`` representing the uptime duration.
+    """
+    m = _RE_UPTIME.search(value.strip())
+    if not m:
+        return timedelta(0)
+    days, hours, minutes = (int(g) if g else 0 for g in m.groups())
+    return timedelta(days=days, hours=hours, minutes=minutes)
+
+
+def parse_epoch_seconds(value: int | float | str) -> datetime | None:
+    """Convert Unix epoch seconds to a UTC-aware ``datetime``.
+
+    A value of ``0`` (or ``"0"``) is treated as *no timestamp available* and
+    returns ``None``, because the controller uses zero as a sentinel for
+    unset timestamps.
+
+    Args:
+        value: Unix timestamp in seconds (int, float, or numeric string).
+
+    Returns:
+        UTC-aware ``datetime``, or ``None`` when ``value`` is zero or
+        non-numeric.
+    """
+    try:
+        ts = float(value)
+    except (ValueError, TypeError):
+        return None
+    if not math.isfinite(ts) or ts == 0:
+        return None
+    return datetime.fromtimestamp(ts, tz=UTC)
+
+
+def parse_epoch_milliseconds(value: int | float | str) -> datetime | None:
+    """Convert Unix epoch milliseconds to a UTC-aware ``datetime``.
+
+    A value of ``0`` (or ``"0"``) is treated as *no timestamp available* and
+    returns ``None``.
+
+    Args:
+        value: Unix timestamp in milliseconds (int, float, or numeric string).
+
+    Returns:
+        UTC-aware ``datetime``, or ``None`` when ``value`` is zero or
+        non-numeric.
+    """
+    try:
+        ts_ms = float(value)
+    except (ValueError, TypeError):
+        return None
+    if not math.isfinite(ts_ms) or ts_ms == 0:
+        return None
+    return datetime.fromtimestamp(ts_ms / 1000.0, tz=UTC)
+
+
+def parse_optional_seconds(value: str | float | int) -> timedelta | None:
+    """Parse float seconds with a ``"NONE"`` sentinel.
+
+    The controller uses the string ``"NONE"`` in some fields to indicate that
+    a duration is not applicable.  This function converts numeric values to
+    ``timedelta`` and the sentinel to ``None``.
+
+    Args:
+        value: Either a numeric seconds value or the string ``"NONE"``
+            (case-insensitive).
+
+    Returns:
+        ``timedelta`` for numeric values, or ``None`` for the sentinel.
+    """
+    if isinstance(value, str) and value.strip().upper() == "NONE":
+        return None
+    try:
+        seconds = float(value)
+    except (ValueError, TypeError):
+        return None
+    if not math.isfinite(seconds):
+        return None
+    return timedelta(seconds=seconds)

--- a/violet_poolcontroller_api/violet_poolcontroller_api/readings.py
+++ b/violet_poolcontroller_api/violet_poolcontroller_api/readings.py
@@ -1,0 +1,515 @@
+# violet-poolController-api - API für Violet Pool Controller
+# Copyright (C) 2024-2026  Xerolux
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Typed, read-only view over a /getReadings API snapshot.
+
+:class:`VioletReadings` wraps the raw ``dict[str, Any]`` returned by the
+controller and exposes documented fields as typed, lazily-evaluated properties.
+It implements the :class:`collections.abc.Mapping` protocol, so all existing
+code that accesses ``coordinator.data.get("KEY")`` or ``"KEY" in
+coordinator.data`` continues to work unchanged — the typed accessors are purely
+additive.
+
+Usage::
+
+    readings = VioletReadings(raw_dict)
+
+    # Backward-compatible dict-style access (works on Mapping)
+    temp = readings.get("onewire1_value")
+
+    # New typed accessors
+    if readings.pump is not None and readings.pump.is_on:
+        print("Pump is running")
+
+    ph = readings.ph  # float | None, already cast from the raw string
+    for idx, state in readings.onewire_states.items():
+        if state is not None and state != OnewireState.OK:
+            print(f"Sensor {idx} fault: {state}")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from datetime import timedelta
+from functools import cached_property
+from types import MappingProxyType
+from typing import Any
+
+from .const_devices import (
+    CoverState,
+    DmxSceneState,
+    OnewireState,
+    OutputState,
+    PvSurplusState,
+    RuleState,
+)
+from .parsers import parse_runtime_string, parse_uptime_string
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (not part of the public API)
+# ---------------------------------------------------------------------------
+
+_DOSING_KEYS = ("DOS_1_CL", "DOS_2_ELO", "DOS_4_PHM", "DOS_5_PHP", "DOS_6_FLOC")
+
+
+def _opt_float(raw: Any) -> float | None:  # noqa: ANN401
+    """Return ``float(raw)`` or ``None`` if the value is absent or non-numeric."""
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_output_state(raw: Any) -> OutputState | None:  # noqa: ANN401
+    """Convert a raw output state value to :class:`OutputState`.
+
+    Handles:
+    * Plain integers / integer strings: ``"4"`` → ``OutputState.MANUAL_ON``
+    * Composite strings with pipe separator: ``"3|PUMP_ANTI_FREEZE"`` →
+      ``OutputState.AUTO_PRIO_ON`` (numeric prefix is used)
+    """
+    if raw is None:
+        return None
+    try:
+        numeric = str(raw).split("|")[0].strip()
+        return OutputState(int(numeric))
+    except (ValueError, KeyError):
+        return None
+
+
+def _parse_dmx_state(raw: Any) -> DmxSceneState | None:  # noqa: ANN401
+    """Convert a raw DMX scene state to :class:`DmxSceneState`."""
+    if raw is None:
+        return None
+    try:
+        return DmxSceneState(int(raw))
+    except (ValueError, KeyError):
+        return None
+
+
+def _parse_rule_state(raw: Any) -> RuleState | None:  # noqa: ANN401
+    """Convert a raw digital rule state to :class:`RuleState`."""
+    if raw is None:
+        return None
+    try:
+        return RuleState(int(raw))
+    except (ValueError, KeyError):
+        return None
+
+
+def _parse_cover_state(raw: Any) -> CoverState | None:  # noqa: ANN401
+    """Convert a COVER_STATE string to :class:`CoverState`."""
+    if raw is None:
+        return None
+    try:
+        return CoverState(str(raw).strip().upper())
+    except ValueError:
+        return None
+
+
+def _parse_onewire_state(raw: Any) -> OnewireState | None:  # noqa: ANN401
+    """Convert a 1-wire sensor state string to :class:`OnewireState`."""
+    if raw is None:
+        return None
+    try:
+        return OnewireState(str(raw).strip())
+    except ValueError:
+        return None
+
+
+def _parse_pv_surplus(raw: Any) -> PvSurplusState | None:  # noqa: ANN401
+    """Convert a PVSURPLUS value to :class:`PvSurplusState`."""
+    if raw is None:
+        return None
+    try:
+        return PvSurplusState(int(raw))
+    except (ValueError, KeyError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public class
+# ---------------------------------------------------------------------------
+
+
+class VioletReadings(Mapping[str, Any]):
+    """Typed, immutable view over a single /getReadings API snapshot.
+
+    Implements :class:`~collections.abc.Mapping` so it is a drop-in
+    replacement for the raw ``dict[str, Any]`` previously returned by
+    :meth:`~violet_poolcontroller_api.api.VioletPoolAPI.get_readings`.
+
+    Typed accessors use :func:`~functools.cached_property` so that repeated
+    access within the same poll cycle is free.  The cache is invalidated
+    automatically when a new :class:`VioletReadings` object is created for
+    the next poll.
+
+    Attributes:
+        raw: :class:`~types.MappingProxyType` view of the underlying dict for
+            read-only access to undocumented or firmware-specific keys that
+            are not yet exposed as typed properties.
+    """
+
+    def __init__(self, raw: dict[str, Any]) -> None:
+        """Wrap a raw /getReadings response.
+
+        Args:
+            raw: The ``dict`` returned by the controller (already flattened
+                and sanitised by :meth:`VioletPoolAPI.get_readings`).
+                A defensive copy is made to prevent external mutations from
+                invalidating the :func:`cached_property` values.
+        """
+        self._raw: dict[str, Any] = dict(raw)
+
+    # ------------------------------------------------------------------
+    # Mapping protocol (required)
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        return self._raw[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._raw)
+
+    def __len__(self) -> int:
+        return len(self._raw)
+
+    # ------------------------------------------------------------------
+    # Raw access
+    # ------------------------------------------------------------------
+
+    @property
+    def raw(self) -> MappingProxyType[str, Any]:
+        """Read-only proxy of the underlying dict.
+
+        Use this to access keys that are not yet exposed as typed properties
+        (e.g. undocumented or firmware-specific fields).
+        """
+        return MappingProxyType(self._raw)
+
+    # ------------------------------------------------------------------
+    # System information
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def sw_version(self) -> str | None:
+        """Software version string of the Violet application (e.g. ``"1.1.9"``)."""
+        v = self._raw.get("SW_VERSION")
+        return str(v).strip() if v is not None else None
+
+    @cached_property
+    def cpu_temp(self) -> float | None:
+        """CPU temperature in °C (main board)."""
+        return _opt_float(self._raw.get("CPU_TEMP"))
+
+    @cached_property
+    def cpu_temp_carrier(self) -> float | None:
+        """CPU temperature in °C (carrier board)."""
+        return _opt_float(self._raw.get("CPU_TEMP_CARRIER"))
+
+    @cached_property
+    def cpu_uptime(self) -> timedelta:
+        """System uptime since last boot as a :class:`~datetime.timedelta`."""
+        raw = self._raw.get("CPU_UPTIME", "")
+        return parse_uptime_string(str(raw))
+
+    @cached_property
+    def memory_usage_mb(self) -> float | None:
+        """Total system memory used in MB."""
+        return _opt_float(self._raw.get("SYSTEM_MEMORY"))
+
+    # ------------------------------------------------------------------
+    # Water chemistry
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def ph(self) -> float | None:
+        """Current pH reading (2 decimal places)."""
+        return _opt_float(self._raw.get("pH_value"))
+
+    @cached_property
+    def ph_min(self) -> float | None:
+        """Today's minimum pH reading (reset nightly at 00:00)."""
+        return _opt_float(self._raw.get("pH_value_min"))
+
+    @cached_property
+    def ph_max(self) -> float | None:
+        """Today's maximum pH reading (reset nightly at 00:00)."""
+        return _opt_float(self._raw.get("pH_value_max"))
+
+    @cached_property
+    def orp(self) -> float | None:
+        """Current ORP / redox potential in mV."""
+        return _opt_float(self._raw.get("orp_value"))
+
+    @cached_property
+    def orp_min(self) -> float | None:
+        """Today's minimum ORP reading in mV."""
+        return _opt_float(self._raw.get("orp_value_min"))
+
+    @cached_property
+    def orp_max(self) -> float | None:
+        """Today's maximum ORP reading in mV."""
+        return _opt_float(self._raw.get("orp_value_max"))
+
+    @cached_property
+    def chlorine(self) -> float | None:
+        """Current chlorine / potentiometric sensor reading in mg/L."""
+        return _opt_float(self._raw.get("pot_value"))
+
+    @cached_property
+    def chlorine_min(self) -> float | None:
+        """Today's minimum chlorine reading in mg/L."""
+        return _opt_float(self._raw.get("pot_value_min"))
+
+    @cached_property
+    def chlorine_max(self) -> float | None:
+        """Today's maximum chlorine reading in mg/L."""
+        return _opt_float(self._raw.get("pot_value_max"))
+
+    # ------------------------------------------------------------------
+    # Main output states
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def pump(self) -> OutputState | None:
+        """Current pump output state.
+
+        Composite states such as ``"3|PUMP_ANTI_FREEZE"`` are reduced to
+        their numeric prefix (``OutputState.AUTO_PRIO_ON`` in that case).
+        """
+        return _parse_output_state(self._raw.get("PUMP"))
+
+    @cached_property
+    def pump_runtime(self) -> timedelta:
+        """Today's pump runtime as a :class:`~datetime.timedelta`."""
+        return parse_runtime_string(str(self._raw.get("PUMP_RUNTIME", "")))
+
+    @cached_property
+    def solar(self) -> OutputState | None:
+        """Current solar output state."""
+        return _parse_output_state(self._raw.get("SOLAR"))
+
+    @cached_property
+    def solar_runtime(self) -> timedelta:
+        """Today's solar runtime."""
+        return parse_runtime_string(str(self._raw.get("SOLAR_RUNTIME", "")))
+
+    @cached_property
+    def heater(self) -> OutputState | None:
+        """Current heater output state."""
+        return _parse_output_state(self._raw.get("HEATER"))
+
+    @cached_property
+    def heater_runtime(self) -> timedelta:
+        """Today's heater runtime."""
+        return parse_runtime_string(str(self._raw.get("HEATER_RUNTIME", "")))
+
+    @cached_property
+    def light(self) -> OutputState | None:
+        """Current pool light output state."""
+        return _parse_output_state(self._raw.get("LIGHT"))
+
+    @cached_property
+    def eco(self) -> OutputState | None:
+        """Current eco-mode output state."""
+        return _parse_output_state(self._raw.get("ECO"))
+
+    @cached_property
+    def backwash(self) -> OutputState | None:
+        """Current backwash output state."""
+        return _parse_output_state(self._raw.get("BACKWASH"))
+
+    @cached_property
+    def backwashrinse(self) -> OutputState | None:
+        """Current backwash-rinse output state."""
+        return _parse_output_state(self._raw.get("BACKWASHRINSE"))
+
+    @cached_property
+    def refill(self) -> OutputState | None:
+        """Current water-refill output state."""
+        return _parse_output_state(self._raw.get("REFILL"))
+
+    # ------------------------------------------------------------------
+    # Special outputs
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def pv_surplus(self) -> PvSurplusState | None:
+        """Current PV surplus state (distinct 0/1/2 scheme, not 0-6).
+
+        ``None`` means the key was absent in the snapshot.
+        """
+        return _parse_pv_surplus(self._raw.get("PVSURPLUS"))
+
+    @cached_property
+    def cover(self) -> CoverState | None:
+        """Current pool cover state.
+
+        ``None`` when no cover is configured or the key is absent.
+        """
+        return _parse_cover_state(self._raw.get("COVER_STATE"))
+
+    # ------------------------------------------------------------------
+    # 1-wire temperature sensors (indices 1-12)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def onewire_temperatures(self) -> dict[int, float | None]:
+        """Current temperature readings for all 12 1-wire sensors.
+
+        Keys are sensor indices 1–12.  A value of ``None`` means no sensor is
+        configured for that slot or the reading is unavailable.
+        """
+        return {
+            i: _opt_float(self._raw.get(f"onewire{i}_value"))
+            for i in range(1, 13)
+        }
+
+    @cached_property
+    def onewire_states(self) -> dict[int, OnewireState | None]:
+        """Fault states for all 12 1-wire sensors.
+
+        Keys are sensor indices 1–12.
+        """
+        return {
+            i: _parse_onewire_state(self._raw.get(f"onewire{i}_state"))
+            for i in range(1, 13)
+        }
+
+    # ------------------------------------------------------------------
+    # Analog / impulse inputs
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def analog_inputs(self) -> dict[int, float | None]:
+        """Current readings for analog inputs ADC1–ADC6 (or ADC5, firmware-dependent).
+
+        Keys are input indices 1–6.
+        """
+        return {
+            i: _opt_float(self._raw.get(f"ADC{i}_value"))
+            for i in range(1, 7)
+        }
+
+    @cached_property
+    def impulse_inputs(self) -> dict[int, float | None]:
+        """Current readings for impulse inputs IMP1–IMP2."""
+        return {
+            i: _opt_float(self._raw.get(f"IMP{i}_value"))
+            for i in range(1, 3)
+        }
+
+    @cached_property
+    def digital_inputs(self) -> dict[int, bool]:
+        """State of digital inputs INPUT1–INPUT12.
+
+        ``True`` means the input is closed (logic 1), ``False`` means open (0).
+        Absent inputs default to ``False``.
+        """
+        return {
+            i: bool(int(self._raw.get(f"INPUT{i}", 0) or 0))
+            for i in range(1, 13)
+        }
+
+    # ------------------------------------------------------------------
+    # Dosing channel output states
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def dosing_states(self) -> dict[str, OutputState | None]:
+        """Output states for all dosing channels.
+
+        Keys: ``"DOS_1_CL"``, ``"DOS_2_ELO"``, ``"DOS_4_PHM"``,
+        ``"DOS_5_PHP"``, ``"DOS_6_FLOC"``.
+        """
+        return {key: _parse_output_state(self._raw.get(key)) for key in _DOSING_KEYS}
+
+    @cached_property
+    def dosing_daily_amounts_ml(self) -> dict[str, int | None]:
+        """Today's dosing amounts in mL for each dosing channel."""
+        return {
+            key: (
+                int(v)
+                if (v := self._raw.get(f"{key}_DAILY_DOSING_AMOUNT_ML")) is not None
+                else None
+            )
+            for key in _DOSING_KEYS
+        }
+
+    # ------------------------------------------------------------------
+    # DMX light scenes (1-12)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def dmx_scenes(self) -> dict[int, DmxSceneState | None]:
+        """States for all 12 DMX light scenes.
+
+        Keys are scene indices 1–12.
+        """
+        return {
+            i: _parse_dmx_state(self._raw.get(f"DMX_SCENE{i}"))
+            for i in range(1, 13)
+        }
+
+    # ------------------------------------------------------------------
+    # Extension relay banks (EXT1 and EXT2, 8 relays each)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def extension_relays(self) -> dict[str, OutputState | None]:
+        """States for all extension relay outputs.
+
+        Keys follow the ``"EXT{bank}_{relay}"`` pattern, e.g. ``"EXT1_3"`` for
+        relay 3 of bank 1.  Keys whose hardware module is absent are still
+        included (they will be ``None``).
+        """
+        return {
+            f"EXT{bank}_{relay}": _parse_output_state(
+                self._raw.get(f"EXT{bank}_{relay}")
+            )
+            for bank in (1, 2)
+            for relay in range(1, 9)
+        }
+
+    # ------------------------------------------------------------------
+    # Digital input switching rules (1-7)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def digital_rules(self) -> dict[int, RuleState | None]:
+        """States for digital-input switching rules 1–7."""
+        return {
+            i: _parse_rule_state(
+                self._raw.get(f"DIGITALINPUTRULE_STATE_DIGITALINPUT_RULE_{i}")
+            )
+            for i in range(1, 8)
+        }
+
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        pump_s = self.pump.name if self.pump is not None else "?"
+        ph_s = f"{self.ph:.2f}" if self.ph is not None else "?"
+        orp_s = f"{self.orp:.0f}" if self.orp is not None else "?"
+        return (
+            f"VioletReadings(keys={len(self._raw)}, "
+            f"pump={pump_s}, pH={ph_s}, ORP={orp_s})"
+        )


### PR DESCRIPTION
## Summary

This PR implements all lessons from reviewing [ylabonte/myviolet](https://github.com/ylabonte/myviolet) and [ylabonte/myviolet-hass](https://github.com/ylabonte/myviolet-hass) — parallel community implementations for the same Violet Pool Controller hardware.

---

### Part 1 — API Package (v0.0.28 → v0.0.29)

#### Typed Enumerations (`const_devices.py`)
| Enum | Type | Highlight |
|------|------|-----------|
| `OutputState` | `IntEnum` | `.is_on`, `.is_manual`, `.is_emergency` properties |
| `DmxSceneState` | `IntEnum` | `.is_on` for the subset of states DMX scenes use |
| `RuleState` | `IntEnum` | DIRULE_* states: INACTIVE / ACTIVE / BLOCKED_BY_RULE / BLOCKED_MANUALLY |
| `CoverState` | `StrEnum` | OPEN / CLOSED / OPENING / CLOSING / STOPPED |
| `OnewireState` | `StrEnum` | OK / CRC_FAULT / DATA_MISSMATCH / NOT_CONNECTED / NO_SENSOR_CONFIGURED |
| `PvSurplusState` | `IntEnum` | OFF / ON_BY_INPUT / ON_BY_HTTP with `.is_on` |

#### Richer Exception Hierarchy (`api.py`)
```
VioletPoolAPIError (base)
├── VioletAuthError           — HTTP 401/403
├── VioletTimeoutError        — request timeout
├── VioletPayloadError        — malformed/unparseable JSON
├── VioletSetpointError       — also ValueError (out-of-range setpoints)
└── VioletUnsafeOperationError — dangerous operation without acknowledgment
```

#### Setpoint Validation (`api.py`)
`validate_setpoint(field, value)` rejects values before the HTTP call (NaN/Inf, out-of-range). Applied in `set_ph_target()`, `set_orp_target()`, `set_min_chlorine_level()`, `set_device_temperature()`, `set_target_value()`.

#### Cover Safety Gate (`api.py`)
New `set_cover_command(action, *, acknowledge_unsafe=False)` raises `VioletUnsafeOperationError` unless explicitly acknowledged. `cover.py` passes `acknowledge_unsafe=True` — safe because the feature requires explicit activation in the config flow.

#### Parsers Module (`parsers.py`)
Six parser functions for controller string/epoch formats → Python `timedelta`/`datetime`.

#### VioletReadings Typed Wrapper (`readings.py`)
`VioletReadings(Mapping[str, Any])` wraps the raw `/getReadings` dict with typed lazy properties for all known fields. Fully backward-compatible — all `coordinator.data.get("KEY")`, `"KEY" in coordinator.data`, `for k, v in coordinator.data.items()` patterns work unchanged.

---

### Part 2 — HA Integration (6 improvements from myviolet-hass)

**1. `ConfigEntryAuthFailed` for auth errors** (`device.py`)
`VioletAuthError` (HTTP 401/403) is re-raised as `ConfigEntryAuthFailed` in `_async_update_data` so HA triggers the re-auth flow instead of retrying indefinitely.

**2. Coordinator setpoint cache** (`device.py`, `climate.py`)
`VioletPoolDataUpdateCoordinator` now has `_setpoint_cache` and `update_setpoint_cache(key, value)` which immediately calls `async_update_listeners()` after a write, so climate entities show the new target temperature without waiting for the next poll cycle.

**3. DMX scenes as `LightEntity`** (`light.py` — new file, `const_features.py`)
DMX scenes 1–12 are now exposed as `LightEntity` with `ColorMode.ONOFF` instead of generic `SwitchEntity`. This is semantically correct and matches how HA models scene lights. `Platform.LIGHT` added to PLATFORMS.

**4. `DataUpdateCoordinator[VioletReadings]`** (`device.py`)
The coordinator is typed as `DataUpdateCoordinator[VioletReadings]` — `_async_update_data` wraps the returned dict in `VioletReadings` at the coordinator boundary, giving mypy full type information for `coordinator.data`.

**5. Hardware serial in `device_info`** (`device.py`)
When the controller exposes a serial-like key in readings (`SERIAL`, `SERIAL_NUMBER`, etc.), it is added to the HA device registry as `serial_number`. The `identifiers` key stays URL-based to preserve existing installations.

**6. Credential normalization** (`config_flow.py`)
Empty username/password strings from the UI are stored as `None` instead of `""`, matching how the API client expects them.

---

## Test plan

- [ ] `ruff check custom_components/violet_pool_controller/` → 0 errors
- [ ] `ruff check violet_poolcontroller_api/violet_poolcontroller_api/` → 0 errors
- [ ] `pytest tests/test_device.py tests/test_entity_state.py tests/test_offline_scenarios.py` → all pass
- [ ] DMX entities appear as `light.*` (not `switch.*`) when LED lighting feature enabled
- [ ] After setting target temperature, entity shows new value immediately (no poll wait)
- [ ] Auth error triggers re-auth flow in HA
- [ ] CI validates full test suite

https://claude.ai/code/session_013L7972GeGaYzhyHVrToF3S

## Summary by Sourcery

Introduce a richer typed API surface (enums, typed readings, parsers, validation, and exceptions) and enhance the Home Assistant integration with safer cover control, better auth/setpoint handling, DMX lights, and improved metadata.

New Features:
- Add typed enumerations and a VioletReadings mapping wrapper to provide structured, strongly-typed access to controller readings.
- Expose parser utilities for controller-specific timestamp and duration formats as reusable helpers.
- Introduce a dedicated cover command API with an explicit safety acknowledgement flag for potentially hazardous operations.
- Expose DMX scenes as light entities instead of switches in the Home Assistant integration.

Bug Fixes:
- Normalize empty credentials to None in the config flow to align with API client expectations and avoid auth issues.
- Ensure authentication failures from the API surface as ConfigEntryAuthFailed so Home Assistant can trigger re-auth instead of endlessly retrying.

Enhancements:
- Refine the API exception hierarchy to distinguish auth, timeout, payload, setpoint, and unsafe-operation errors for more granular handling.
- Validate all setpoint writes against documented ranges and reject non-finite or out-of-range values before sending them to the controller.
- Return typed VioletReadings snapshots from API and coordinator calls to improve type safety while preserving Mapping compatibility.
- Add a coordinator-level setpoint cache so climate entities reflect new target temperatures immediately after writes.
- Include controller serial-number-like data in Home Assistant device info when available.

Build:
- Bump the API package version to 0.0.29 to reflect the new typed surface and behaviour changes.

Tests:
- Extend test fixtures and Home Assistant mocks to cover new exception types, typed readings, and platforms (light, update).