### PR TITLE
Compatibility fixes for violet-poolcontroller-api exports and update entity device_info

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -26,8 +26,20 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from violet_poolcontroller_api.api import VioletAuthError, VioletPoolAPI, VioletPoolAPIError
-from violet_poolcontroller_api.readings import VioletReadings
+from violet_poolcontroller_api.api import VioletPoolAPI, VioletPoolAPIError
+
+try:
+    from violet_poolcontroller_api.api import VioletAuthError
+except ImportError:
+    class VioletAuthError(VioletPoolAPIError):
+        """Compatibility fallback for older violet-poolcontroller-api releases."""
+
+try:
+    from violet_poolcontroller_api.readings import VioletReadings
+except ImportError:
+    class VioletReadings(dict):
+        """Compatibility fallback for older violet-poolcontroller-api releases."""
+
 
 from .config_entry_helpers import (
     extract_api_host,
@@ -82,6 +94,7 @@ class VioletPoolControllerDevice:
         self.hass = hass
         self.config_entry = config_entry
         self.api = api
+        self._api = api
         self._available = False
         self._session = async_get_clientsession(hass)
         self._data: dict[str, Any] = {}
@@ -275,6 +288,7 @@ class VioletPoolControllerDevice:
 
             # Replace the old API with the new one
             self.api = new_api
+            self._api = new_api
 
             # Update device configuration
             self.api_url = new_api_url

--- a/custom_components/violet_pool_controller/update.py
+++ b/custom_components/violet_pool_controller/update.py
@@ -63,12 +63,7 @@ class VioletPoolControllerUpdateEntity(CoordinatorEntity, UpdateEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device info."""
-        return {
-            "identifiers": {(DOMAIN, self.coordinator.device.device_id)},
-            "name": self.coordinator.device.device_name,
-            "manufacturer": "PoolDigital GmbH",
-            "model": self.coordinator.device.device_model,
-        }
+        return self.coordinator.device.device_info
 
     @property
     def installed_version(self) -> str | None:


### PR DESCRIPTION
### Motivation
- Prevent integration import failures when an older `violet-poolcontroller-api` release does not export `VioletAuthError` or `VioletReadings`.
- Avoid runtime crash in the update entity caused by referencing a nonexistent device attribute (`device_model`).

### Description
- Add compatibility fallbacks so `VioletAuthError` and `VioletReadings` are defined when they are missing from the installed `violet-poolcontroller-api` package, preventing import errors during setup (`device.py`).
- Maintain a legacy `_api` alias synchronized with the public `api` attribute when the device is initialized or its API is reconfigured to preserve compatibility with existing code that references `_api` (`device.py`).
- Change the update entity to return the device's canonical `device_info` instead of referencing `device_model`, eliminating the `AttributeError` on entity creation (`update.py`).

### Testing
- Ran `python -m ruff check custom_components/violet_pool_controller/device.py custom_components/violet_pool_controller/update.py` and it passed.
- Ran `python -m compileall -q custom_components/violet_pool_controller/device.py custom_components/violet_pool_controller/update.py` and it passed.
- Executed `pytest -q tests/test_device.py`; an initial `ModuleNotFoundError` for `violet_poolcontroller_api.readings` was observed and resolved by the fallback, and a subsequent run produced failures because this environment lacks async pytest support (async tests are not natively supported), so results are inconclusive for async test coverage.
- Performed basic static checks (`git diff --check`) with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1d07ac28832eaaf96b7a0779e1ec)

## Summary by Sourcery

Ensure compatibility with varying violet-poolcontroller-api exports and align entity metadata with the device’s canonical info.

Bug Fixes:
- Use the device’s canonical device_info for the update entity to avoid AttributeError from referencing a nonexistent device_model attribute.

Enhancements:
- Maintain a legacy _api attribute in sync with the public api on device initialization and API reconfiguration to preserve backward compatibility for existing consumers.