### PR TITLE
Fix API publish workflow dispatch version

### DIFF
--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -29,11 +29,25 @@ jobs:
       - name: Install build tools
         run: pip install build twine
 
-      - name: Extract version from tag
+      - name: Extract package version
         id: version
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          VERSION="${TAG#api-v}"
+          TOML_VERSION=$(python3 -c "
+          import tomllib
+          with open('violet_poolcontroller_api/pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['project']['version'])
+          ")
+
+          if [[ "$GITHUB_REF" == refs/tags/api-v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#api-v}"
+          else
+            TAG="api-v$TOML_VERSION"
+            VERSION="$TOML_VERSION"
+            echo "No api-v* tag ref detected ($GITHUB_REF); using pyproject.toml version for workflow_dispatch."
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Publishing violet-poolController-api version: $VERSION"
@@ -46,10 +60,10 @@ jobs:
               data = tomllib.load(f)
           print(data['project']['version'])
           ")
-          TAG_VERSION="${{ steps.version.outputs.version }}"
-          if [ "$TOML_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version mismatch: pyproject.toml=$TOML_VERSION, tag=$TAG_VERSION"
-            echo "Please update violet_poolcontroller_api/pyproject.toml version to $TAG_VERSION"
+          RELEASE_VERSION="${{ steps.version.outputs.version }}"
+          if [ "$TOML_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Version mismatch: pyproject.toml=$TOML_VERSION, release=$RELEASE_VERSION"
+            echo "Please update violet_poolcontroller_api/pyproject.toml version to $RELEASE_VERSION"
             exit 1
           fi
           echo "Version check passed: $TOML_VERSION"


### PR DESCRIPTION
### Motivation

- The `publish-api` workflow treated non-tag refs (e.g. `refs/heads/main` during `workflow_dispatch`) as if they were release tags, causing version mismatches against `violet_poolcontroller_api/pyproject.toml`.
- The workflow needs to allow manual runs while still validating that the package version in `pyproject.toml` matches the release version when a tag is present.

### Description

- Renamed the step to `Extract package version` and read the package version from `violet_poolcontroller_api/pyproject.toml` into `TOML_VERSION` using `tomllib`.
- If `GITHUB_REF` matches `refs/tags/api-v*` the workflow derives `VERSION` from the tag, otherwise it sets `TAG` to `api-v$TOML_VERSION` and uses the `pyproject.toml` version for `VERSION` (for `workflow_dispatch`).
- Updated the verification step to compare `TOML_VERSION` against the extracted release output (`${{ steps.version.outputs.version }}`) and adjusted log messages accordingly.

### Testing

- Executed a Python assertion to verify the new conditional tag logic is present in `.github/workflows/publish-api.yml`, which passed.
- Read `violet_poolcontroller_api/pyproject.toml` with Python to confirm the package version can be loaded, which passed.
- Ran `git diff --check` to ensure no whitespace or diff errors, which passed.
- Parsed the updated workflow YAML with `PyYAML` to validate syntax, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f20242da0832e8ceba9e40d2da80f)

## Summary by Sourcery

CI:
- Update the publish-api workflow to read the package version from pyproject.toml and fall back to it when no api-v* tag ref is present, while tightening the version consistency check and log messages.