### PR TITLE
fix: Remove redundant .keys() in dictionary iteration

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -699,7 +699,7 @@ class VioletPoolControllerDevice:
             """Check if any valid keys start with the given prefix."""
             return any(
                 k.startswith(prefix) and self._data.get(k) is not None
-                for k in self._data.keys()
+                for k in self._data
             )
 
         # Check standalone mode vs dosing module


### PR DESCRIPTION
- Use `for k in self._data` instead of `for k in self._data.keys()`
- Fixes ruff SIM118 lint error

## Summary by Sourcery

Enhancements:
- Replace explicit .keys() usage with direct dictionary iteration in prefix-based key checks to improve code clarity and satisfy linting requirements.