### PR TITLE
fix: Add missing @property decorator to device_info method

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -724,6 +724,7 @@ class VioletPoolControllerDevice:
 
         return extra_modules
 
+    @property
     def device_info(self) -> dict[str, Any]:
         """Return device information for Home Assistant."""
         # Build a readable model string from currently detected hardware modules.


### PR DESCRIPTION
- Fixes TypeError: device_info was a method, not a property
- HA device_registry.async_get_or_create expects a dict, not a method
- Resolves entity creation errors across all platforms

## Summary by Sourcery

Bug Fixes:
- Convert device_info from a method to a property to avoid TypeError and ensure a dict is returned to the Home Assistant device registry.