### PR TITLE
fix: Remove @property decorator from _detect_current_hardware_modules

### DIFF
--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -686,7 +686,6 @@ class VioletPoolControllerDevice:
         """Return the number of consecutive failures."""
         return self._consecutive_failures
 
-    @property
     def _detect_current_hardware_modules(self) -> list[str]:
         """Detect currently present hardware modules from API data (not cached).
 


### PR DESCRIPTION
- Method is called with () on line 732, so it cannot be a property
- @property would make it callable without (), but code uses ()
- Fixes: TypeError: 'list' object is not callable

## Summary by Sourcery

Bug Fixes:
- Fix a TypeError caused by calling a property-returned list as if it were a callable.