### PR TITLE
Add Safety Settings to reconfigure flow

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -160,6 +160,7 @@ def _migrate_duplicate_prefix_entity_ids(
 
 
 def _disable_unsafe_switches(
+    hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     config_entry_id: str,
 ) -> None:
@@ -169,6 +170,26 @@ def _disable_unsafe_switches(
     because they require mandatory time limits to prevent equipment damage,
     chemical overdose, and flooding.
     """
+    from .const import CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
+
+    # Get the config entry to check the allow_unsafe_switches setting
+    entry = hass.config_entries.async_get_entry(config_entry_id)
+    if not entry:
+        return
+
+    allow_unsafe = entry.options.get(
+        CONF_ALLOW_UNSAFE_SWITCHES,
+        entry.data.get(CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES),
+    )
+
+    # If user explicitly allowed unsafe switches, don't disable them
+    if allow_unsafe:
+        _LOGGER.warning(
+            "⚠️ SAFETY WARNING: Unsafe switches are ENABLED for '%s'. "
+            "User accepts full responsibility for risks (equipment damage, chemical overdose, flooding)",
+            config_entry_id,
+        )
+        return
     # Keys of switches that should be disabled for safety
     unsafe_switch_keys = {
         "DOS_1_CL",     # Chlorine dosing
@@ -302,7 +323,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Auto-disable unsafe switches (dosing, backwash, refill) that require
         # mandatory time limits via Services instead of switches
-        _disable_unsafe_switches(er.async_get(hass), entry.entry_id)
+        _disable_unsafe_switches(hass, er.async_get(hass), entry.entry_id)
 
         # Load platforms
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -159,6 +159,74 @@ def _migrate_duplicate_prefix_entity_ids(
         )
 
 
+def _disable_unsafe_switches(
+    entity_registry: er.EntityRegistry,
+    config_entry_id: str,
+) -> None:
+    """Auto-disable unsafe manual control switches for safety.
+
+    Switches like dosing, backwash, and refill should use Services instead
+    because they require mandatory time limits to prevent equipment damage,
+    chemical overdose, and flooding.
+    """
+    # Keys of switches that should be disabled for safety
+    unsafe_switch_keys = {
+        "DOS_1_CL",     # Chlorine dosing
+        "DOS_2_ELO",    # Electrolysis dosing
+        "DOS_4_PHM",    # pH- dosing
+        "DOS_5_PHP",    # pH+ dosing
+        "DOS_6_FLOC",   # Flocculant
+        "BACKWASH",     # Backwash
+        "BACKWASHRINSE", # Backwash rinse
+        "REFILL",       # Water refill
+    }
+
+    disabled_count = 0
+    prefix = f"{config_entry_id}_"
+
+    for entity_entry in er.async_entries_for_config_entry(entity_registry, config_entry_id):
+        # Only process switches
+        if entity_entry.domain != "switch":
+            continue
+
+        # Extract key from unique_id (format: "{entry_id}_{key}")
+        if not entity_entry.unique_id.startswith(prefix):
+            continue
+
+        key = entity_entry.unique_id[len(prefix):]
+
+        # Check if this is an unsafe switch
+        if key not in unsafe_switch_keys:
+            continue
+
+        # Skip if already disabled
+        if not entity_entry.enabled:
+            continue
+
+        # Disable the entity
+        _LOGGER.warning(
+            "🚨 SAFETY: Auto-disabling unsafe switch '%s' (%s). Use Services instead!",
+            entity_entry.entity_id,
+            key,
+        )
+        try:
+            entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=er.RegistryEntryDisabler.INTEGRATION)
+            disabled_count += 1
+        except Exception as err:
+            _LOGGER.error(
+                "Failed to disable unsafe switch '%s': %s",
+                entity_entry.entity_id,
+                err,
+            )
+
+    if disabled_count > 0:
+        _LOGGER.warning(
+            "🚨 SAFETY: Disabled %d unsafe switches for '%s'. Use Services with time limits instead!",
+            disabled_count,
+            config_entry_id,
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Violet Pool Controller from a config entry.
 
@@ -231,6 +299,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # platforms are loaded so that the registry already contains the
         # corrected entity_ids when entities re-register themselves.
         _migrate_duplicate_prefix_entity_ids(er.async_get(hass), entry.entry_id)
+
+        # Auto-disable unsafe switches (dosing, backwash, refill) that require
+        # mandatory time limits via Services instead of switches
+        _disable_unsafe_switches(er.async_get(hass), entry.entry_id)
 
         # Load platforms
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -182,14 +182,6 @@ def _disable_unsafe_switches(
         entry.data.get(CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES),
     )
 
-    # If user explicitly allowed unsafe switches, don't disable them
-    if allow_unsafe:
-        _LOGGER.warning(
-            "⚠️ SAFETY WARNING: Unsafe switches are ENABLED for '%s'. "
-            "User accepts full responsibility for risks (equipment damage, chemical overdose, flooding)",
-            config_entry_id,
-        )
-        return
     # Keys of switches that should be disabled for safety
     unsafe_switch_keys = {
         "DOS_1_CL",     # Chlorine dosing
@@ -202,9 +194,42 @@ def _disable_unsafe_switches(
         "REFILL",       # Water refill
     }
 
-    disabled_count = 0
     prefix = f"{config_entry_id}_"
 
+    if allow_unsafe:
+        # If user explicitly allowed unsafe switches, re-enable any previously disabled ones
+        _LOGGER.warning(
+            "⚠️ SAFETY WARNING: Unsafe switches are ENABLED for '%s'. "
+            "User accepts full responsibility for risks (equipment damage, chemical overdose, flooding)",
+            config_entry_id,
+        )
+        re_enabled_count = 0
+        for entity_entry in er.async_entries_for_config_entry(entity_registry, config_entry_id):
+            if entity_entry.domain != "switch":
+                continue
+            if not entity_entry.unique_id.startswith(prefix):
+                continue
+            key = entity_entry.unique_id[len(prefix):]
+            if key not in unsafe_switch_keys:
+                continue
+            if entity_entry.disabled_by != er.RegistryEntryDisabler.INTEGRATION:
+                continue
+            _LOGGER.info("Re-enabling unsafe switch '%s' (%s)", entity_entry.entity_id, key)
+            try:
+                entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
+                re_enabled_count += 1
+            except Exception as err:
+                _LOGGER.error(
+                    "Failed to re-enable unsafe switch '%s': %s",
+                    entity_entry.entity_id,
+                    err,
+                )
+        if re_enabled_count > 0:
+            _LOGGER.info("Re-enabled %d unsafe switches for '%s'", re_enabled_count, config_entry_id)
+        return
+
+    # Disable unsafe switches for safety
+    disabled_count = 0
     for entity_entry in er.async_entries_for_config_entry(entity_registry, config_entry_id):
         # Only process switches
         if entity_entry.domain != "switch":

--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -444,13 +444,13 @@ class ConfigFlow(
             return self.async_abort(reason="reconfigure_failed")
 
         if user_input is not None:
-            updated_data = dict(reconfigure_entry.data)
-            updated_data[CONF_ALLOW_UNSAFE_SWITCHES] = user_input.get(
+            updated_options = dict(reconfigure_entry.options)
+            updated_options[CONF_ALLOW_UNSAFE_SWITCHES] = user_input.get(
                 CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
             )
             self.hass.config_entries.async_update_entry(
                 reconfigure_entry,
-                data=updated_data,
+                options=updated_options,
             )
             await self.hass.config_entries.async_reload(reconfigure_entry.entry_id)
             return self.async_abort(reason="reconfigure_successful")
@@ -461,9 +461,12 @@ class ConfigFlow(
                 {
                     vol.Optional(
                         CONF_ALLOW_UNSAFE_SWITCHES,
-                        default=reconfigure_entry.data.get(
+                        default=reconfigure_entry.options.get(
                             CONF_ALLOW_UNSAFE_SWITCHES,
-                            DEFAULT_ALLOW_UNSAFE_SWITCHES,
+                            reconfigure_entry.data.get(
+                                CONF_ALLOW_UNSAFE_SWITCHES,
+                                DEFAULT_ALLOW_UNSAFE_SWITCHES,
+                            ),
                         ),
                     ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 }

--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -396,6 +396,95 @@ class ConfigFlow(
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle reconfiguration menu - choose what to reconfigure."""
+        if user_input is not None:
+            choice = user_input.get("reconfigure_option", "connection")
+            if choice == "safety":
+                return await self.async_step_reconfigure_safety()
+            return await self.async_step_reconfigure_connection()
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        "reconfigure_option", default="connection"
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value="connection",
+                                    label="🌐 Connection settings",
+                                ),
+                                selector.SelectOptionDict(
+                                    value="safety",
+                                    label="🚨 Safety settings",
+                                ),
+                            ],
+                            mode=selector.SelectSelectorMode.LIST,
+                        )
+                    ),
+                }
+            ),
+            description_placeholders={
+                "info": "What would you like to reconfigure?",
+            },
+        )
+
+    async def async_step_reconfigure_safety(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of safety settings."""
+        from .const import CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
+
+        reconfigure_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if reconfigure_entry is None:
+            return self.async_abort(reason="reconfigure_failed")
+
+        if user_input is not None:
+            updated_data = dict(reconfigure_entry.data)
+            updated_data[CONF_ALLOW_UNSAFE_SWITCHES] = user_input.get(
+                CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
+            )
+            self.hass.config_entries.async_update_entry(
+                reconfigure_entry,
+                data=updated_data,
+            )
+            await self.hass.config_entries.async_reload(reconfigure_entry.entry_id)
+            return self.async_abort(reason="reconfigure_successful")
+
+        return self.async_show_form(
+            step_id="reconfigure_safety",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_ALLOW_UNSAFE_SWITCHES,
+                        default=reconfigure_entry.data.get(
+                            CONF_ALLOW_UNSAFE_SWITCHES,
+                            DEFAULT_ALLOW_UNSAFE_SWITCHES,
+                        ),
+                    ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                }
+            ),
+            description_placeholders={
+                "warning": (
+                    "🚨 CRITICAL SAFETY WARNING 🚨\n\n"
+                    "Enabling unsafe switches allows direct manual control of:\n"
+                    "• Dosing systems (chemical overdose risk)\n"
+                    "• Backwash/Rinse (equipment damage risk)\n"
+                    "• Water Refill (flooding/overflow risk)\n\n"
+                    "These operations can run INDEFINITELY without time limits!\n\n"
+                    "SAFE ALTERNATIVE: Use Services instead - they require mandatory time limits.\n\n"
+                    "⚠️ Only enable this if you fully understand and accept the risks!"
+                ),
+            },
+        )
+
+    async def async_step_reconfigure_connection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle reconfiguration of connection settings."""
         errors = {}
         reconfigure_entry = self.hass.config_entries.async_get_entry(
@@ -453,7 +542,7 @@ class ConfigFlow(
                 errors["base"] = constants.ERROR_CANNOT_CONNECT
 
         return self.async_show_form(
-            step_id="reconfigure",
+            step_id="reconfigure_connection",
             data_schema=vol.Schema(
                 {
                     vol.Required(

--- a/custom_components/violet_pool_controller/config_flow_support.py
+++ b/custom_components/violet_pool_controller/config_flow_support.py
@@ -284,6 +284,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 return await self.async_step_features()
             if choice == "sensors":
                 return await self.async_step_sensors()
+            if choice == "safety":
+                return await self.async_step_safety()
             return await self.async_step_settings()
 
         return self.async_show_form(
@@ -301,6 +303,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 ),
                                 selector.SelectOptionDict(
                                     value="sensors", label="📊 Select sensors"
+                                ),
+                                selector.SelectOptionDict(
+                                    value="safety", label="🚨 Safety settings"
                                 ),
                                 selector.SelectOptionDict(
                                     value="settings", label="⚙️ Change settings"
@@ -386,6 +391,44 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="sensors",
             data_schema=self._get_sensor_schema(),
+        )
+
+    async def async_step_safety(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle safety settings in options flow."""
+        from .const import CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
+
+        if user_input is not None:
+            self._updated_options.update(user_input)
+            final_options = {**self.current_config, **self._updated_options}
+            return self.async_create_entry(title="", data=final_options)
+
+        return self.async_show_form(
+            step_id="safety",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_ALLOW_UNSAFE_SWITCHES,
+                        default=self.current_config.get(
+                            CONF_ALLOW_UNSAFE_SWITCHES,
+                            DEFAULT_ALLOW_UNSAFE_SWITCHES,
+                        ),
+                    ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                }
+            ),
+            description_placeholders={
+                "warning": (
+                    "🚨 CRITICAL SAFETY WARNING 🚨\n\n"
+                    "Enabling unsafe switches allows direct manual control of:\n"
+                    "• Dosing systems (chemical overdose risk)\n"
+                    "• Backwash/Rinse (equipment damage risk)\n"
+                    "• Water Refill (flooding/overflow risk)\n\n"
+                    "These operations can run INDEFINITELY without time limits!\n\n"
+                    "SAFE ALTERNATIVE: Use Services instead - they require mandatory time limits.\n\n"
+                    "⚠️ Only enable this if you fully understand and accept the risks!"
+                ),
+            },
         )
 
     async def async_step_settings(

--- a/custom_components/violet_pool_controller/const.py
+++ b/custom_components/violet_pool_controller/const.py
@@ -86,6 +86,7 @@ CONF_DISINFECTION_METHOD = "disinfection_method"
 CONF_ENABLE_DIAGNOSTIC_LOGGING = "enable_diagnostic_logging"
 CONF_DOSING_STANDALONE = "dosing_standalone"
 CONF_INVERT_COVER = "invert_cover"
+CONF_ALLOW_UNSAFE_SWITCHES = "allow_unsafe_switches"
 
 # ACTION_* constants come from violet_poolcontroller_api.const_api (wildcard
 # import above) - do not redefine them here, local copies drift from the API.
@@ -106,6 +107,7 @@ DEFAULT_DISINFECTION_METHOD = "chlorine"
 DEFAULT_ENABLE_DIAGNOSTIC_LOGGING = False
 DEFAULT_DOSING_STANDALONE = False
 DEFAULT_INVERT_COVER = False
+DEFAULT_ALLOW_UNSAFE_SWITCHES = False
 
 # =============================================================================
 # POOL CONFIGURATION

--- a/custom_components/violet_pool_controller/sensor_modules/base.py
+++ b/custom_components/violet_pool_controller/sensor_modules/base.py
@@ -327,6 +327,10 @@ def determine_state_class(key: str) -> SensorStateClass | None:
     if key.endswith("_REMAINING_RANGE"):
         return None
 
+    # DI-Rule stopwatch sensors return formatted strings like "1d 2h 30m 45s"
+    if "DIGITALINPUTRULE_STATE_DIGITALINPUT_RULE_STOPWATCH" in key:
+        return None
+
     if key in _ALL_TEXT_SENSORS or is_timestamp_key or key in NO_UNIT_SENSORS:
         return None
     # Handle contact sensors (e.g., CLOSE_CONTACT) which return

--- a/custom_components/violet_pool_controller/strings.json
+++ b/custom_components/violet_pool_controller/strings.json
@@ -121,12 +121,20 @@
         "description": "A Violet Pool Controller was discovered on the network.\n\nName: **{name}**\nIP: **{host}**\n\nWould you like to set up this controller now?"
       },
       "reconfigure": {
-        "title": "Reconfigure Connection",
+        "title": "Reconfigure Violet Pool Controller",
+        "description": "What would you like to reconfigure?\n\nController: **{controller_name}**",
+        "data": {
+          "reconfigure_option": "Select what to reconfigure"
+        }
+      },
+      "reconfigure_connection": {
+        "title": "Reconfigure Connection Settings",
         "description": "Update the connection settings for your controller.\n\nController: **{controller_name}**",
         "data": {
           "host": "IP Address",
           "port": "TCP Port",
           "use_ssl": "Use SSL/HTTPS",
+          "verify_ssl": "Verify SSL Certificate",
           "polling_interval": "Polling Interval (s)",
           "timeout_duration": "Timeout (s)",
           "retry_attempts": "Retry Attempts"
@@ -135,9 +143,20 @@
           "host": "New controller IP or DNS name",
           "port": "TCP port (default 80)",
           "use_ssl": "Enable HTTPS",
+          "verify_ssl": "Verify the SSL certificate. Disable for self-signed certificates.",
           "polling_interval": "Data polling interval (10–3600s)",
           "timeout_duration": "Maximum wait time per request",
           "retry_attempts": "Number of retry attempts"
+        }
+      },
+      "reconfigure_safety": {
+        "title": "🚨 Safety Settings",
+        "description": "{warning}",
+        "data": {
+          "allow_unsafe_switches": "Allow manual safety-critical switches"
+        },
+        "data_description": {
+          "allow_unsafe_switches": "Enable direct control of dosing, backwash & refill (requires mandatory time limits via Services)"
         }
       },
       "repair": {

--- a/custom_components/violet_pool_controller/strings.json
+++ b/custom_components/violet_pool_controller/strings.json
@@ -192,7 +192,7 @@
     "step": {
       "init": {
         "title": "Adjust Pool Settings",
-        "description": "**What would you like to configure?**\n\nEnable/disable features\nSelect sensors\nChange settings\n\n**Tip:** You can return to this selection at any time.",
+        "description": "**What would you like to configure?**\n\nEnable/disable features\nSelect sensors\n🚨 Safety settings\nChange settings\n\n**Tip:** You can return to this selection at any time.",
         "data": {
           "config_option": "Select configuration area"
         },
@@ -207,6 +207,16 @@
       "sensors": {
         "title": "Select Sensors",
         "description": "**Choose which sensors to display**\n\nOnly selected sensors are shown in Home Assistant\nChanges take effect immediately\n\n**Tip:** Only select the sensors you actually want to monitor!"
+      },
+      "safety": {
+        "title": "🚨 Safety Settings",
+        "description": "{warning}",
+        "data": {
+          "allow_unsafe_switches": "Allow manual safety-critical switches"
+        },
+        "data_description": {
+          "allow_unsafe_switches": "Enable direct control of dosing, backwash & refill (requires mandatory time limits via Services)"
+        }
       },
       "settings": {
         "title": "General Settings",


### PR DESCRIPTION
## Summary

Extends the reconfigure flow to support Safety Settings configuration alongside connection settings, completing the user's request to integrate Safety Settings into the reconfigure flow.

- Refactor `async_step_reconfigure()` to display a menu with "Connection settings" and "Safety settings" options
- Add `async_step_reconfigure_safety()` handler for configuring `allow_unsafe_switches` in reconfigure context
- Rename original reconfigure logic to `async_step_reconfigure_connection()` with proper step_id
- Add SSL certificate verification (`CONF_VERIFY_SSL`) toggle to reconfigure connection form
- Update `strings.json` with translations for all new reconfigure steps

## Test plan

- [ ] Verify reconfigure flow shows menu with two options
- [ ] Test "Connection settings" path updates IP, port, SSL, and polling settings
- [ ] Test "Safety settings" path toggles `allow_unsafe_switches` without requiring connection info
- [ ] Verify warning text displays in Safety Settings reconfigure step
- [ ] Check that both paths properly reload the integration after changes

https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd)_

## Summary by Sourcery

Extend Violet Pool Controller configuration flows with safety settings and automatic handling of unsafe switches.

New Features:
- Add safety settings to the config reconfigure flow, allowing users to toggle unsafe manual control switches independently of connection settings.
- Expose a safety settings step in the options flow for configuring whether unsafe switches are allowed.

Enhancements:
- Automatically disable or re-enable predefined unsafe switches (dosing, backwash, refill, etc.) based on the safety configuration when setting up an entry.
- Treat DI rule stopwatch sensors as non-numeric/text sensors to avoid assigning an inappropriate state class.