### PR TITLE
Fix: Use 'disabled' instead of 'enabled' for RegistryEntry

### DIFF
--- a/custom_components/violet_pool_controller/__init__.py
+++ b/custom_components/violet_pool_controller/__init__.py
@@ -246,7 +246,7 @@ def _disable_unsafe_switches(
             continue
 
         # Skip if already disabled
-        if not entity_entry.enabled:
+        if entity_entry.disabled:
             continue
 
         # Disable the entity


### PR DESCRIPTION
## Critical Bug Fix

Fixes AttributeError that was blocking integration setup after safety improvements merged in #369.

## Issue
`RegistryEntry` object has `disabled` attribute (boolean), not `enabled`. The code was checking `if not entity_entry.enabled` which caused:

```
AttributeError: 'RegistryEntry' object has no attribute 'enabled'
```

## Solution
Changed attribute check from:
```python
if not entity_entry.enabled:
```

To:
```python
if entity_entry.disabled:
```

This allows the auto-disable unsafe switches logic to properly check if an entity is already disabled before attempting to disable it.

## Impact
- Resolves setup errors when integration loads
- Allows auto-disabling of unsafe switches to work correctly
- No functional change to safety logic, only attribute name fix

https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd)_

## Summary by Sourcery

Bug Fixes:
- Resolve AttributeError during integration setup by referencing the existing disabled attribute on registry entries instead of a non-existent enabled attribute.