### PR TITLE
docs: Add comprehensive CHANGELOG with breaking changes (German)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog - Violet Pool Controller
+
+## ⚠️ BREAKING CHANGES - Version 2.0.0-beta.10
+
+### 🚨 **SICHERHEIT: Automatische Deaktivierung kritischer Schalter**
+
+**WICHTIG:** Ab dieser Version werden folgende Schalter **automatisch deaktiviert** für Sicherheit:
+
+- **Dosierungsschalter** (Chlor, pH-, pH+, Flockmittel, Elektrolyse)
+- **Rückspülung/Spülung** (Backwash/Rinse)
+- **Wassernachfüllung** (Refill)
+
+**Grund:** Diese Operationen können zu schweren Schäden führen, wenn sie ohne Zeitlimit laufen:
+- ⚠️ **Chemische Überdosierung** → Poolwasser beschädigt, Gesundheitsrisiko
+- ⚠️ **Ausrüstungsschaden** → Pumpen, Filter, Ventile zerstört
+- ⚠️ **Überflutung** → Tank überläuft, Wasserschaden im Haus
+
+**Neue Sicherheitslogik:**
+1. ✅ Alle unsicheren Schalter sind **standardmäßig deaktiviert**
+2. ✅ Services erfordern **Pflicht-Zeitangabe** für sichere Kontrolle
+3. ✅ Benutzer können in Sicherheitseinstellungen manuell aktivieren (mit Warnung!)
+4. ✅ Ausführliche Warnmeldungen im Log, wenn Schalter deaktiviert werden
+
+**Was ändert sich für dich?**
+
+| Vorher | Nachher |
+|--------|---------|
+| ❌ Schalter kann unbegrenzt laufen | ✅ Schalter deaktiviert (sicher) |
+| ❌ Risiko von Schäden | ✅ Risiko minimiert |
+| ❌ Manuelle Kontrolle ohne Limits | ✅ Services mit Pflicht-Zeitlimit |
+
+**Wie nutze ich diese Schalter weiterhin?**
+
+Nutze die **Services** stattdessen - sie erfordern eine Zeitangabe:
+- `violet_pool_controller.smart_dosing` - für Dosierung
+- `violet_pool_controller.control_pump` - für Pumpensteuerung
+- Weitere Services für Rückspülung, Nachfüllung, etc.
+
+**Oder: Schalter manuell aktivieren (Experten)**
+
+Wenn du die Risiken kennst und akzeptierst, kannst du die unsicheren Schalter aktivieren:
+1. Gehe zu **Einstellungen → Geräte & Services → Violet Pool Controller**
+2. Öffne **Optionen → 🚨 Sicherheitseinstellungen**
+3. Aktiviere "Manuelle Steuerung kritischer Schalter erlauben"
+4. ⚠️ Akzeptiere die Warnung und nutze Schalter mit Vorsicht!
+
+---
+
+## Version 2.0.0-beta.10
+
+### ✨ Neue Funktionen
+
+- **Sicherheitseinstellungen im Reconfigure-Flow** - Sicherheit kann jetzt ohne vollständige Neukonfiguration angepasst werden
+- **Auto-Disable für unsichere Schalter** - Automatische Migration für bestehende Installationen
+
+### 🐛 Bugfixes
+
+- Behobener AttributeError bei `RegistryEntry.enabled` (sollte `disabled` sein)
+- Korrekte Speicherung von Sicherheitseinstellungen in Config-Optionen
+- Re-Enable-Logik für Schalter wenn Sicherheitsüberschreibung aktiviert wird
+
+### 🔧 Technische Verbesserungen
+
+- Sicherheitseinstellungen jetzt in `options` statt `data` gespeichert
+- Fallback-Checking (options → data) für Rückwärtskompatibilität
+- Separate Reconfigure-Flows für Verbindung und Sicherheit
+- SSL-Verifikation im Reconfigure-Flow konfigurierbar
+
+---
+
+## Version 2.0.0-beta.9
+
+### ✨ Neue Funktionen
+
+- Onewire ROM-Code Sensorunterstützung (zeigt Adresse statt °C)
+- DI-Rule Verbleibzeit-Anzeige in humanlesbarem Format (1d 2h 30m 45s)
+- Verbesserte Hardware-Modul-Erkennung (aktuell statt cached)
+
+### 🐛 Bugfixes
+
+- Onewire Romcode zeigt jetzt korrekt Adresse statt Temperatur
+- DI-Rule Stopwatch als Text-Sensor (nicht numerisch)
+- Hardware-Module werden basierend auf aktuellen Daten erkannt
+
+### 📦 Dependencies
+
+- Aktualisiert auf violet-poolController-api 0.0.24
+
+---
+
+## Hinweise zur Sicherheit
+
+Diese Integration kontrolliert kritische Poolausrüstung. Sicherheit steht an erster Stelle:
+
+- ✅ Alle manuellen Steuerschalter für kritische Operationen sind standardmäßig deaktiviert
+- ✅ Services erfordern obligatorische Zeitangaben
+- ✅ Ausführliches Logging bei kritischen Operationen
+- ✅ Benutzer müssen Risiken explizit akzeptieren
+
+**Kontakt & Support:**
+- GitHub Issues: https://github.com/Xerolux/violet-hass/issues
+- E-Mail: git@xerolux.de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - Violet Pool Controller
 
+> **Language Note:** This changelog is available in German. For English release notes, see the GitHub releases page.
+
 ## ⚠️ BREAKING CHANGES - Version 2.0.0-beta.10
 
 ### 🚨 **SICHERHEIT: Automatische Deaktivierung kritischer Schalter**
@@ -11,7 +13,7 @@
 - **Wassernachfüllung** (Refill)
 
 **Grund:** Diese Operationen können zu schweren Schäden führen, wenn sie ohne Zeitlimit laufen:
-- ⚠️ **Chemische Überdosierung** → Poolwasser beschädigt, Gesundheitsrisiko
+- ⚠️ **Chemische Überdosierung** → Wasserqualität beeinträchtigt, Gesundheitsrisiko
 - ⚠️ **Ausrüstungsschaden** → Pumpen, Filter, Ventile zerstört
 - ⚠️ **Überflutung** → Tank überläuft, Wasserschaden im Haus
 
@@ -32,9 +34,10 @@
 **Wie nutze ich diese Schalter weiterhin?**
 
 Nutze die **Services** stattdessen - sie erfordern eine Zeitangabe:
-- `violet_pool_controller.smart_dosing` - für Dosierung
+- `violet_pool_controller.smart_dosing` - für Dosierungen (pH-, pH+, Chlor, Flockmittel)
 - `violet_pool_controller.control_pump` - für Pumpensteuerung
-- Weitere Services für Rückspülung, Nachfüllung, etc.
+- `violet_pool_controller.manage_pv_surplus` - für PV-Überschuss-Steuerung
+- Zusätzliche Services: `control_dmx_scenes`, `set_light_color_pulse`, `manage_digital_rules`, `test_output`
 
 **Oder: Schalter manuell aktivieren (Experten)**
 
@@ -57,12 +60,12 @@ Wenn du die Risiken kennst und akzeptierst, kannst du die unsicheren Schalter ak
 
 - Behobener AttributeError bei `RegistryEntry.enabled` (sollte `disabled` sein)
 - Korrekte Speicherung von Sicherheitseinstellungen in Config-Optionen
-- Re-Enable-Logik für Schalter wenn Sicherheitsüberschreibung aktiviert wird
+- Re-Enable-Logik für Schalter, wenn Sicherheitsüberschreibung aktiviert wird
 
 ### 🔧 Technische Verbesserungen
 
 - Sicherheitseinstellungen jetzt in `options` statt `data` gespeichert
-- Fallback-Checking (options → data) für Rückwärtskompatibilität
+- Fallback-Prüfung (options → data) für Rückwärtskompatibilität
 - Separate Reconfigure-Flows für Verbindung und Sicherheit
 - SSL-Verifikation im Reconfigure-Flow konfigurierbar
 
@@ -72,14 +75,14 @@ Wenn du die Risiken kennst und akzeptierst, kannst du die unsicheren Schalter ak
 
 ### ✨ Neue Funktionen
 
-- Onewire ROM-Code Sensorunterstützung (zeigt Adresse statt °C)
-- DI-Rule Verbleibzeit-Anzeige in humanlesbarem Format (1d 2h 30m 45s)
+- OneWire-ROM-Code-Sensorunterstützung (zeigt Adresse statt °C)
+- DI-Rule Verbleibzeit-Anzeige in lesbarem Format (1d 2h 30m 45s)
 - Verbesserte Hardware-Modul-Erkennung (aktuell statt cached)
 
 ### 🐛 Bugfixes
 
-- Onewire Romcode zeigt jetzt korrekt Adresse statt Temperatur
-- DI-Rule Stopwatch als Text-Sensor (nicht numerisch)
+- OneWire-ROM-Code zeigt jetzt korrekt Adresse statt Temperatur
+- DI-Rule-Stoppuhr als Text-Sensor (nicht numerisch)
 - Hardware-Module werden basierend auf aktuellen Daten erkannt
 
 ### 📦 Dependencies
@@ -88,14 +91,17 @@ Wenn du die Risiken kennst und akzeptierst, kannst du die unsicheren Schalter ak
 
 ---
 
-## Hinweise zur Sicherheit
+## Sicherheitsrichtlinie
 
-Diese Integration kontrolliert kritische Poolausrüstung. Sicherheit steht an erster Stelle:
+Diese Integration kontrolliert kritische Poolausrüstung mit strikter Sicherheit:
 
-- ✅ Alle manuellen Steuerschalter für kritische Operationen sind standardmäßig deaktiviert
+**Siehe auch:** [⚠️ BREAKING CHANGES - Version 2.0.0-beta.10](#breaking-changes---version-200-0-beta10) für vollständige Informationen zur Sicherheitsimplementierung, automatischen Deaktivierung kritischer Schalter und erforderlichen Services mit Zeitlimits.
+
+**Sicherheitsmerkmale:**
+- ✅ Automatische Deaktivierung unsicherer Schalter (standardmäßig)
 - ✅ Services erfordern obligatorische Zeitangaben
-- ✅ Ausführliches Logging bei kritischen Operationen
-- ✅ Benutzer müssen Risiken explizit akzeptieren
+- ✅ Explizite Benutzer-Opt-in für manuelle Kontrolle (mit Warnungen)
+- ✅ Umfassendes Logging bei kritischen Operationen
 
 **Kontakt & Support:**
 - GitHub Issues: https://github.com/Xerolux/violet-hass/issues


### PR DESCRIPTION
## Comprehensive Release Notes for HACS Users

Adds CHANGELOG.md with prominent breaking changes notice about critical safety improvements.

## What's included

**Breaking Changes (prominently at top):**
- ⚠️ Auto-disabling of unsafe switches (dosing, backwash, refill)
- ⚠️ Mandatory time limits via Services instead
- ⚠️ Security settings opt-in for existing installations

**User-friendly content (German):**
- Clear explanation of WHY changes were made (safety risks)
- Before/After comparison table
- Step-by-step instructions for users
- Information about migration to Services
- Optional manual override with warnings

**Technical details:**
- Version history
- Feature lists
- Bug fixes
- Dependencies

## Why this matters

Users updating in HACS will immediately see:
1. What changed (breaking changes at top)
2. Why it changed (safety/risk explanation)
3. How to adapt (alternative approaches)
4. How to override if needed (with warnings)

This ensures transparency and helps prevent confusion or support issues.

https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE939BMKwc8spvQXHjS3Hd)_

## Summary by Sourcery

Add a German CHANGELOG outlining recent versions with a strong focus on newly introduced safety-related breaking changes.

Documentation:
- Introduce a comprehensive German CHANGELOG highlighting critical safety-related breaking changes and their rationale for users.
- Document new features, bug fixes, and technical improvements for versions 2.0.0-beta.10 and 2.0.0-beta.9, including safety settings and dependency updates.
- Add security notes and support contact information to guide users in safely operating the Violet Pool Controller integration.