### PR TITLE
Fix test suite (green), HA 2026.8 config_entry deprecation, and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,11 @@ config/.test_token
 # Debug scripts with credentials
 scripts/debug_tools/
 
+# Local live hardware test scripts (use env vars in tracked live_*_check.py instead).
+# Never commit hardcoded controller credentials/IPs.
+tests/live_integration_check.py
+tests/live_*_local.py
+
 # Docker volumes (config directory with sensitive data)
 config/.storage/
 config/home-assistant.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,8 +172,29 @@ pytest tests/test_api.py::test_function_name -v
 
 - **`service_schemas.py`** - Voluptuous schemas for all services.
 
+- **`refill_overflow_service.py`** - Refill & overflow protection service handlers (`VioletRefillOverflowServiceHandlers`):
+  - `configure_refill`, `configure_overflow`, `get_refill_status`, `get_overflow_status`
+
+- **`refill_overflow_schemas.py`** - Voluptuous schemas for the refill/overflow services.
+
+- **`http_control.py`** - Direct HTTP control layer (`VioletControlClient`) wrapping the API's `setFunctionManually` endpoint for the `*_http` service family (`control_pump_http`, `control_heater_http`, `manual_dosing_http`, etc.).
+
+- **`hardware_config.py`** - Hardware configuration discovery/caching (digital inputs, extension relays, dosing-standalone detection).
+
+- **`calibration_helper.py`** - Sensor calibration history parsing and date-format handling.
+
+- **`digital_input_helper.py`** - Digital input rule/state interpretation helpers.
+
+- **`entity_names.py`** - Centralized entity naming/label resolution.
+
+- **`sensor_organization.py`** - Sensor grouping and organization helpers.
+
+- **`update_helper.py`** - Firmware info parsing for the update entity (`parse_firmware_info`).
+
+- **`state_constants.py`** - Internal state interpretation constants.
+
 - **`services.py`** - Service registration and composition:
-  - `VioletServiceHandlers` composes control + diagnostic handlers
+  - `VioletServiceHandlers` composes control + diagnostic + refill/overflow handlers
   - Registers all services with Home Assistant
 
 #### Constants Organization (Modular)
@@ -484,6 +505,18 @@ violet-hass/
 │       ├── service_helpers.py        # Shared service utilities
 │       ├── service_manager.py        # Service manager
 │       ├── service_schemas.py        # Service Voluptuous schemas
+│       ├── refill_overflow_service.py # Refill/overflow service handlers
+│       ├── refill_overflow_schemas.py # Refill/overflow schemas
+│       ├── http_control.py           # Direct setFunctionManually HTTP layer
+│       ├── hardware_config.py        # Hardware config discovery/caching
+│       ├── calibration_helper.py     # Calibration history parsing
+│       ├── digital_input_helper.py   # Digital input rule helpers
+│       ├── entity_names.py           # Entity naming/label resolution
+│       ├── sensor_organization.py    # Sensor grouping helpers
+│       ├── update_helper.py          # Firmware info parsing
+│       ├── state_constants.py        # State interpretation constants
+│       ├── config_flow_support.py    # Config/options flow mixins
+│       ├── config_entry_helpers.py   # Config entry URL/migration helpers
 │       ├── error_codes.py            # Error code mappings
 │       ├── error_handler.py          # VioletErrorCodes & error utilities
 │       ├── diagnostics.py            # HA diagnostics support

--- a/custom_components/violet_pool_controller/device.py
+++ b/custom_components/violet_pool_controller/device.py
@@ -860,6 +860,7 @@ class VioletPoolDataUpdateCoordinator(DataUpdateCoordinator[VioletReadings]):
             _LOGGER,
             name=name,
             update_interval=timedelta(seconds=polling_interval),
+            config_entry=device.config_entry,
         )
         self.device = device
         self._setpoint_cache: dict[str, float] = {}

--- a/custom_components/violet_pool_controller/refill_overflow_service.py
+++ b/custom_components/violet_pool_controller/refill_overflow_service.py
@@ -28,7 +28,7 @@ class VioletRefillOverflowServiceHandlers:
     async def handle_configure_refill(self, call: ServiceCall) -> None:
         """Configure water refill system."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        refill_type = call.data.get("refill_type")
+        refill_type = int(call.data.get("refill_type", 0))
 
         if not 1 <= refill_type <= 3:
             raise HomeAssistantError(f"Refill type must be 1-3, got {refill_type}")

--- a/custom_components/violet_pool_controller/service_control.py
+++ b/custom_components/violet_pool_controller/service_control.py
@@ -620,6 +620,7 @@ class VioletControlServiceHandlers:
                 "Backwash duration is required for safety. "
                 "Specify duration_seconds (10-3600 seconds)"
             )
+        backwash_seconds = float(duration_seconds or 0)
 
         for coordinator in coordinators:
             try:
@@ -629,20 +630,20 @@ class VioletControlServiceHandlers:
                 if action == "run":
                     await control.set_backwash_run()
                     _LOGGER.info(
-                        "Backwash started on %s with %ds timeout",
+                        "Backwash started on %s with %ss timeout",
                         device_name,
-                        duration_seconds,
+                        backwash_seconds,
                     )
 
                     # Auto-stop backwash after specified duration for safety
                     async def auto_stop_backwash() -> None:
-                        await asyncio.sleep(duration_seconds)
+                        await asyncio.sleep(backwash_seconds)
                         try:
                             await control.set_backwash_abort()
                             _LOGGER.info(
-                                "Backwash auto-stopped on %s after %ds",
+                                "Backwash auto-stopped on %s after %ss",
                                 device_name,
-                                duration_seconds,
+                                backwash_seconds,
                             )
                             await coordinator.async_request_refresh()
                         except Exception as err:
@@ -666,7 +667,7 @@ class VioletControlServiceHandlers:
     async def handle_manual_dosing_http(self, call: ServiceCall) -> None:
         """Trigger manual dosing via HTTP (NEW API)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        dosing_system = call.data.get("dosing_system")
+        dosing_system = str(call.data.get("dosing_system", ""))
         runtime = call.data.get("runtime_seconds", 30)
 
         dosing_index = DOSING_INDEX_MAP.get(dosing_system)
@@ -709,6 +710,7 @@ class VioletControlServiceHandlers:
                 "Refill duration is REQUIRED for safety to prevent flooding! "
                 "Specify duration_seconds (10-3600 seconds)"
             )
+        refill_seconds = float(duration_seconds or 0)
 
         for coordinator in coordinators:
             try:
@@ -718,20 +720,20 @@ class VioletControlServiceHandlers:
                 if action == "fill":
                     await control.set_function_manually("REFILL", "ON")
                     _LOGGER.critical(
-                        "🚨 WATER REFILL STARTED on %s - WILL AUTO-STOP after %ds",
+                        "🚨 WATER REFILL STARTED on %s - WILL AUTO-STOP after %ss",
                         device_name,
-                        duration_seconds,
+                        refill_seconds,
                     )
 
                     # Auto-stop refill after specified duration for CRITICAL SAFETY
                     async def auto_stop_refill() -> None:
-                        await asyncio.sleep(duration_seconds)
+                        await asyncio.sleep(refill_seconds)
                         try:
                             await control.set_function_manually("REFILL", "OFF")
                             _LOGGER.critical(
-                                "🚨 WATER REFILL AUTO-STOPPED on %s after %ds (OVERFLOW PREVENTED)",
+                                "🚨 WATER REFILL AUTO-STOPPED on %s after %ss (OVERFLOW PREVENTED)",
                                 device_name,
-                                duration_seconds,
+                                refill_seconds,
                             )
                             await coordinator.async_request_refresh()
                         except Exception as err:
@@ -932,7 +934,7 @@ class VioletControlServiceHandlers:
     async def handle_configure_temp_rule(self, call: ServiceCall) -> None:
         """Configure temperature rule (TEMPRULE_1-8)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        rule_id = call.data.get("rule_id")  # 1-8
+        rule_id = int(call.data.get("rule_id", 0))  # 1-8
         enabled = call.data.get("enabled", True)
 
         if not 1 <= rule_id <= 8:
@@ -982,7 +984,7 @@ class VioletControlServiceHandlers:
     async def handle_configure_analog_rule(self, call: ServiceCall) -> None:
         """Configure analog input rule (ANALOGRULE_1-8)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        rule_id = call.data.get("rule_id")
+        rule_id = int(call.data.get("rule_id", 0))
         enabled = call.data.get("enabled", True)
 
         if not 1 <= rule_id <= 8:
@@ -1032,7 +1034,7 @@ class VioletControlServiceHandlers:
     ) -> None:
         """Configure switching input rule (SWITCHINGRULE_1-8)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        rule_id = call.data.get("rule_id")
+        rule_id = int(call.data.get("rule_id", 0))
         enabled = call.data.get("enabled", True)
 
         if not 1 <= rule_id <= 8:
@@ -1074,7 +1076,7 @@ class VioletControlServiceHandlers:
     async def handle_configure_timer_rule(self, call: ServiceCall) -> None:
         """Configure timer rule (TIMERRULE_1-8)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        rule_id = call.data.get("rule_id")
+        rule_id = int(call.data.get("rule_id", 0))
         enabled = call.data.get("enabled", True)
 
         if not 1 <= rule_id <= 8:
@@ -1117,7 +1119,7 @@ class VioletControlServiceHandlers:
         """Enable/disable any rule type."""
         coordinators = await self.manager.get_coordinators_for_call(call)
         rule_type = call.data.get("rule_type")
-        rule_id = call.data.get("rule_id")
+        rule_id = int(call.data.get("rule_id", 0))
         enabled = call.data.get("enabled", True)
 
         valid_types = [
@@ -1157,7 +1159,7 @@ class VioletControlServiceHandlers:
     async def handle_control_extension_relay(self, call: ServiceCall) -> None:
         """Control extension relay outputs (EXT1_1 to EXT8_8)."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        relay_id = call.data.get("relay_id")
+        relay_id = int(call.data.get("relay_id", 0))
 
         if not 1 <= relay_id <= 8:
             raise HomeAssistantError(f"Relay ID must be 1-8, got {relay_id}")
@@ -1219,7 +1221,7 @@ class VioletControlServiceHandlers:
     ) -> None:
         """Configure sensor calibration offsets and multipliers."""
         coordinators = await self.manager.get_coordinators_for_call(call)
-        sensor_id = call.data.get("sensor_id")
+        sensor_id = int(call.data.get("sensor_id", 0))
 
         if not 1 <= sensor_id <= 12:
             raise HomeAssistantError(f"Sensor ID must be 1-12, got {sensor_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ _test_dir = Path(__file__).parent
 if str(_test_dir) not in sys.path:
     sys.path.insert(0, str(_test_dir))
 
+# Prefer the REAL violet_poolcontroller_api package over the stale mock below.
+# The outer monorepo directory (violet_poolcontroller_api/) has no __init__.py,
+# so Python treats it as a namespace package and shadows the installed wheel /
+# the inner real package (violet_poolcontroller_api/violet_poolcontroller_api/).
+# By inserting the outer source directory at sys.path[0], the inner real package
+# is discovered first and the detection logic below correctly skips the mock.
+_api_src_dir = _test_dir.parent / "violet_poolcontroller_api"
+if _api_src_dir.is_dir() and str(_api_src_dir) not in sys.path:
+    sys.path.insert(0, str(_api_src_dir))
+
 # Setup Home Assistant mocks first
 # Import as a module to ensure proper execution context
 import conftest_ha_mock  # noqa: F401,E402
@@ -302,6 +312,16 @@ def _create_mock_violet_api_module():
     sanitizer_module.InputSanitizer = InputSanitizer
     mock_module.utils_sanitizer = sanitizer_module
 
+    # Mirror the real package's top-level public API so that imports like
+    # ``from violet_poolcontroller_api import VioletAuthError`` work even when
+    # tests fall back to this mock (real package unavailable).
+    mock_module.VioletPoolAPI = api_module.VioletPoolAPI
+    mock_module.VioletPoolAPIError = api_module.VioletPoolAPIError
+    mock_module.VioletAuthError = api_module.VioletAuthError
+    mock_module.VioletTimeoutError = api_module.VioletTimeoutError
+    mock_module.VioletUnsafeOperationError = api_module.VioletUnsafeOperationError
+    mock_module.InputSanitizer = InputSanitizer
+
     return mock_module
 
 
@@ -368,6 +388,24 @@ def pytest_configure(config):
     except Exception:
         pass
 
+    # Windows-only: pytest-homeassistant-custom-component calls
+    # ``pytest_socket.disable_socket(allow_unix_socket=True)`` from its
+    # ``pytest_runtest_setup`` hook. On Windows AF_UNIX is unavailable, so
+    # asyncio's ProactorEventLoop cannot create its self-pipe and every test
+    # errors out during setup. Neutralise disable_socket on Windows so the loop
+    # can be created; Linux CI keeps strict socket blocking (AF_UNIX allowed).
+    if sys.platform == "win32":
+        try:
+            import pytest_socket
+
+            def _no_op_disable_socket(*_args, **_kwargs):
+                pass
+
+            pytest_socket.disable_socket = _no_op_disable_socket
+            pytest_socket.enable_socket()
+        except Exception:
+            pass
+
     # Patch the thread check in pytest-homeassistant-custom-component
     # to allow newer Home Assistant thread names
     try:
@@ -408,23 +446,32 @@ def pytest_configure(config):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_fixture_setup(fixturedef, request):
-    """Enable sockets before event_loop fixture is set up.
+    """Enable sockets before fixtures need them (Windows-only workaround).
 
     On Windows, asyncio's ProactorEventLoop needs socket.socketpair() to create
     its internal IPC pipe. pytest-homeassistant-custom-component disables ALL
     socket creation on Windows (since AF_UNIX is not available there), which
     prevents the event loop from being created at all.
 
-    This hook intercepts event_loop fixture setup specifically and temporarily
-    re-enables sockets so the loop can be created. The sockets are re-disabled
-    by pytest-hacc's pytest_runtest_setup hook for the actual test body.
+    Newer pytest-asyncio versions provision the event loop from different
+    fixtures than ``event_loop``, so on Windows we re-enable sockets for every
+    fixture setup. Linux CI is unaffected (sockets stay disabled there because
+    AF_UNIX is allowed and the loop never needs an AF_INET socketpair).
     """
+    if sys.platform != "win32":
+        return
     if fixturedef.argname == "event_loop":
         try:
             import pytest_socket
             pytest_socket.enable_socket()
         except Exception:
             pass
+        return
+    try:
+        import pytest_socket
+        pytest_socket.enable_socket()
+    except Exception:
+        pass
 
 
 # NOTE: The hass / device_registry / entity_registry fixtures are provided by


### PR DESCRIPTION
## Summary

Long-running integration branch that brings the test suite fully green, fixes an upcoming Home Assistant breaking change, and consolidates earlier code-quality work.

### Headline changes
- **Test suite green**: 473 passed, 2 skipped, 0 errors (was: 43 failed + 40 errors)
- **HA 2026.8 compatibility**: pass `config_entry` explicitly to `DataUpdateCoordinator` (avoids the `relies on ContextVar` error that becomes hard-failing in HA 2026.8)
- **Code quality refactor**: dead-code removal, type safety improvements, consolidated service handlers
- **API package bumped to 0.0.33**

### Test infrastructure fixes (`tests/conftest.py`)
- Prefer the **real** `violet_poolcontroller_api` package over the stale mock by inserting the inner monorepo source dir at `sys.path[0]` (the outer namespace directory was shadowing the installed wheel)
- Expose missing top-level mock exports (`VioletAuthError`, etc.) for the fallback path
- Windows-only socket workaround so `pytest-homeassistant-custom-component` no longer blocks the ProactorEventLoop self-pipe (Linux CI unaffected)

### Type safety
- Coerce service-call data to `int`/`float`/`str` in `service_control.py` / `refill_overflow_service.py` to eliminate 20 mypy errors (None-safe operands)

### Security
- Removed a local untracked script that contained hardcoded controller credentials
- Hardened `.gitignore` against accidental commits of local live-test scripts

### Docs
- `CLAUDE.md`: documented the previously-missing modules (`refill_overflow_service.py`, `http_control.py`, `hardware_config.py`, etc.)

## Verification
- `ruff check`: clean
- `mypy`: clean
- `pytest`: 473 passed, 2 skipped

## ⚠️ Follow-up required (outside this PR)
The controller password that was exposed in the deleted local script should be **rotated** on the device — that cannot be done from code.

## Summary by Sourcery

Update Home Assistant integration for upcoming config_entry requirements, harden tests and Windows socket handling, and improve type safety for service handlers and documentation.

Bug Fixes:
- Ensure mocked violet_poolcontroller_api exposes the same top-level exceptions as the real package to prevent import errors in tests.
- Work around pytest-homeassistant-custom-component socket blocking on Windows so asyncio event loops and tests can run correctly.
- Prevent unsafe None or non-numeric values in service calls by coercing IDs and durations to int/float/str before use.

Enhancements:
- Pass the config_entry into DataUpdateCoordinator-based devices to align with newer Home Assistant expectations.
- Clarify CLAUDE.md with documentation for new service and helper modules and updated service composition details.

Documentation:
- Document newly added service and helper modules in CLAUDE.md, including refill/overflow services, HTTP control, hardware configuration, and state helpers.

Tests:
- Align test-time mock API package with the real package’s public surface and adjust fixture setup to keep Home Assistant tests passing on Windows.