### PR TITLE
Add LSI and CSI saturation index calculators with local input numbers

### DIFF
--- a/custom_components/violet_pool_controller/const_features.py
+++ b/custom_components/violet_pool_controller/const_features.py
@@ -448,6 +448,98 @@ for i in range(6):
     )
 
 # =============================================================================
+# LOCAL LSI CALCULATOR INPUTS
+# =============================================================================
+
+LSI_INPUT_DEFINITIONS = [
+    {
+        "key": "lsi_ph",
+        "name": "LSI pH Value",
+        "translation_key": "lsi_ph",
+        "min_value": 0.0,
+        "max_value": 14.0,
+        "step": 0.01,
+        "default_value": None,
+        "icon": "mdi:ph",
+        "unit_of_measurement": "pH",
+        "device_class": NumberDeviceClass.PH,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    {
+        "key": "lsi_temperature",
+        "name": "LSI Temperature",
+        "translation_key": "lsi_temperature",
+        "min_value": 0.0,
+        "max_value": 60.0,
+        "step": 0.1,
+        "default_value": None,
+        "icon": "mdi:thermometer-water",
+        "unit_of_measurement": "°C",
+        "device_class": None,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    {
+        "key": "lsi_tds",
+        "name": "LSI TDS",
+        "translation_key": "lsi_tds",
+        "min_value": 1.0,
+        "max_value": 10000.0,
+        "step": 10.0,
+        "default_value": None,
+        "icon": "mdi:water-opacity",
+        "unit_of_measurement": "mg/l",
+        "device_class": None,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    {
+        "key": "lsi_calcium",
+        "name": "LSI Calcium Hardness",
+        "translation_key": "lsi_calcium",
+        "min_value": 1.0,
+        "max_value": 2000.0,
+        "step": 1.0,
+        "default_value": None,
+        "icon": "mdi:water-hardness",
+        "unit_of_measurement": "mg/l",
+        "device_class": None,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    {
+        "key": "lsi_alkalinity",
+        "name": "LSI Carbonate Alkalinity",
+        "translation_key": "lsi_alkalinity",
+        "min_value": 1.0,
+        "max_value": 500.0,
+        "step": 1.0,
+        "default_value": None,
+        "icon": "mdi:flask-outline",
+        "unit_of_measurement": "mg/l",
+        "device_class": None,
+        "entity_category": EntityCategory.CONFIG,
+    },
+]
+
+CSI_INPUT_DEFINITIONS = [
+    {
+        **definition,
+        "key": definition["key"].replace("lsi_", "csi_"),
+        "name": definition["name"].replace("LSI", "CSI"),
+        "translation_key": definition["translation_key"].replace("lsi_", "csi_"),
+    }
+    for definition in LSI_INPUT_DEFINITIONS
+]
+
+# Controller readings that can satisfy saturation-index inputs automatically.
+# Inputs without source fields must be provided manually before an LSI/CSI value is shown.
+SATURATION_INDEX_SOURCE_FIELDS = {
+    "ph": ("PH", "pH_value"),
+    "temperature_c": ("onewire1_value",),
+    "tds_mg_l": (),
+    "calcium_hardness_mg_l_as_caco3": (),
+    "carbonate_alkalinity_mg_l_as_caco3": (),
+}
+
+# =============================================================================
 # NUMBER ENTITIES (SETPOINTS)
 # =============================================================================
 

--- a/custom_components/violet_pool_controller/number.py
+++ b/custom_components/violet_pool_controller/number.py
@@ -12,6 +12,7 @@ import logging
 from typing import cast
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.helpers.restore_state import RestoreEntity
 
 try:
     from homeassistant.components.number import NumberMode
@@ -21,11 +22,18 @@ except ImportError:
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from violet_poolcontroller_api.api import VioletPoolAPIError
 from violet_poolcontroller_api.utils_sanitizer import InputSanitizer
 
-from .const import CONF_ACTIVE_FEATURES, DOMAIN, SETPOINT_DEFINITIONS
+from .const import (
+    CONF_ACTIVE_FEATURES,
+    CSI_INPUT_DEFINITIONS,
+    DOMAIN,
+    LSI_INPUT_DEFINITIONS,
+    SETPOINT_DEFINITIONS,
+)
 from .device import VioletPoolDataUpdateCoordinator
 from .entity import VioletPoolControllerEntity
 
@@ -390,6 +398,86 @@ class VioletNumber(VioletPoolControllerEntity, NumberEntity):
             ) from err
 
 
+class VioletSaturationIndexInputNumber(VioletPoolControllerEntity, NumberEntity, RestoreEntity):
+    """Local number entity used as an input for saturation index calculators."""
+
+    entity_description: NumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: VioletPoolDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        description: NumberEntityDescription,
+        input_config: dict,
+    ) -> None:
+        """Initialize the local saturation index input number."""
+        super().__init__(coordinator, config_entry, description)
+        self._input_key = str(input_config["key"])
+        self._store_key = str(input_config.get("store_key", "lsi_inputs"))
+        default_value = input_config.get("default_value")
+        self._default_value = float(default_value) if default_value is not None else None
+        self._attr_native_min_value = input_config["min_value"]
+        self._attr_native_max_value = input_config["max_value"]
+        self._attr_native_step = input_config["step"]
+        self._attr_entity_category = input_config.get("entity_category")
+        self._value: float | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last input value and publish it to the calculator value store."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in {"unknown", "unavailable"}:
+            try:
+                self._value = float(last_state.state)
+            except (ValueError, TypeError):
+                self._value = None
+        if self._value is None:
+            self._value = self._default_value
+        self._update_saturation_index_store(self._value)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current local input value."""
+        return self._value
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the local input value without writing to the controller API."""
+        try:
+            new_value = float(value)
+        except (ValueError, TypeError) as err:
+            raise HomeAssistantError(
+                translation_key="invalid_value",
+                translation_domain=DOMAIN,
+                translation_placeholders={"detail": str(err)},
+            ) from err
+
+        if new_value < self._attr_native_min_value or new_value > self._attr_native_max_value:
+            raise HomeAssistantError(
+                translation_key="value_out_of_range",
+                translation_domain=DOMAIN,
+                translation_placeholders={
+                    "value": str(new_value),
+                    "min": str(self._attr_native_min_value),
+                    "max": str(self._attr_native_max_value),
+                },
+            )
+
+        self._value = new_value
+        self._update_saturation_index_store(new_value)
+        self.async_write_ha_state()
+
+    def _update_saturation_index_store(self, value: float | None) -> None:
+        """Store the input value in hass.data for the matching result sensor."""
+        domain_data = self.hass.data.setdefault(DOMAIN, {})
+        entry_store = domain_data.setdefault(f"{self.config_entry.entry_id}_{self._store_key}", {})
+        entry_store[self._input_key] = value
+        if hasattr(self, "hass"):
+            async_dispatcher_send(
+                self.hass,
+                f"{DOMAIN}_{self.config_entry.entry_id}_{self._store_key}_updated",
+            )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -426,6 +514,38 @@ async def async_setup_entry(
         return
 
     entities: list[NumberEntity] = []
+
+    if "ph_control" in active_features:
+        for store_key, input_definitions in (
+            ("lsi_inputs", LSI_INPUT_DEFINITIONS),
+            ("csi_inputs", CSI_INPUT_DEFINITIONS),
+        ):
+            input_store = hass.data.setdefault(DOMAIN, {}).setdefault(
+                f"{config_entry.entry_id}_{store_key}", {}
+            )
+            for input_config in input_definitions:
+                input_config = {**input_config, "store_key": store_key}
+                input_store.setdefault(str(input_config["key"]), input_config.get("default_value"))
+                description = NumberEntityDescription(
+                    key=str(input_config["key"]),
+                    name=str(input_config["name"]),
+                    icon=input_config.get("icon"),  # type: ignore[arg-type]
+                    native_unit_of_measurement=(
+                        input_config.get("unit_of_measurement")
+                    ),  # type: ignore[arg-type]
+                    device_class=input_config.get("device_class"),  # type: ignore[arg-type]
+                    entity_category=input_config.get("entity_category"),  # type: ignore[arg-type]
+                    translation_key=cast(str | None, input_config.get("translation_key")),
+                    mode=cast(
+                        "NumberMode | None",
+                        NumberMode.BOX if NumberMode is not None else "box",
+                    ),
+                )
+                entities.append(
+                    VioletSaturationIndexInputNumber(
+                        coordinator, config_entry, description, input_config
+                    )
+                )
 
     for setpoint_config in SETPOINT_DEFINITIONS:
         setpoint_name = str(setpoint_config["name"])

--- a/custom_components/violet_pool_controller/sensor.py
+++ b/custom_components/violet_pool_controller/sensor.py
@@ -48,12 +48,13 @@ from .sensor_modules import (
     VioletAPIRequestRateSensor,
     VioletAverageLatencySensor,
     VioletConnectionLatencySensor,
+    VioletCSISensor,
     VioletDosingStateSensor,
     VioletErrorCodeSensor,
     VioletFlowRateSensor,
     VioletHealthSensor,
-    VioletLSISensor,
     VioletLastEventAgeSensor,
+    VioletLSISensor,
     VioletPumpPowerSensor,
     VioletSensor,
     VioletStatusSensor,
@@ -179,10 +180,15 @@ def _create_special_sensors(
     # Pool Health Sensor (aggregate state: ok / warning / error / offline)
     sensors.append(VioletHealthSensor(coordinator, config_entry))
     _LOGGER.debug("Pool health sensor created")
-    
-    # LSI Calculator
-    sensors.append(VioletLSISensor(coordinator, config_entry))
-    _LOGGER.debug("LSI Calculator sensor created")
+
+    # LSI/CSI Calculators
+    sensors.extend(
+        [
+            VioletLSISensor(coordinator, config_entry),
+            VioletCSISensor(coordinator, config_entry),
+        ]
+    )
+    _LOGGER.debug("LSI and CSI calculator sensors created")
 
     # Flow Rate Sensor
     flow_keys_present = any(key in coordinator.data for key in _FLOW_RATE_SOURCE_KEYS)

--- a/custom_components/violet_pool_controller/sensor_modules/__init__.py
+++ b/custom_components/violet_pool_controller/sensor_modules/__init__.py
@@ -33,6 +33,7 @@ from .monitoring import (
 )
 from .specialized import (
     VioletActiveErrorsSensor,
+    VioletCSISensor,
     VioletDosingStateSensor,
     VioletErrorCodeSensor,
     VioletFlowRateSensor,
@@ -59,6 +60,7 @@ __all__ = [
     "VioletSystemHealthSensor",
     # Specialized
     "VioletActiveErrorsSensor",
+    "VioletCSISensor",
     "VioletDosingStateSensor",
     "VioletErrorCodeSensor",
     "VioletFlowRateSensor",

--- a/custom_components/violet_pool_controller/sensor_modules/specialized.py
+++ b/custom_components/violet_pool_controller/sensor_modules/specialized.py
@@ -8,8 +8,8 @@
 from __future__ import annotations
 
 import logging
-import re
 import math
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -20,9 +20,16 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 
-from ..const import DIAGNOSTIC_PROBLEM_KEYS, DOSING_STATE_DESCRIPTIONS, OMNI_FAULTY_STATES
+from ..const import (
+    DIAGNOSTIC_PROBLEM_KEYS,
+    DOMAIN,
+    DOSING_STATE_DESCRIPTIONS,
+    OMNI_FAULTY_STATES,
+    SATURATION_INDEX_SOURCE_FIELDS,
+)
 from ..device import VioletPoolDataUpdateCoordinator
 from ..entity import VioletPoolControllerEntity
 from ..error_codes import get_error_info
@@ -464,7 +471,182 @@ class VioletFlowRateSensor(VioletPoolControllerEntity, SensorEntity):
         )
 
 
-class VioletLSISensor(VioletPoolControllerEntity, SensorEntity):
+def _as_optional_float(value: object) -> float | None:
+    """Convert a value to float while treating missing HA states as absent."""
+    if value in (None, "", "unknown", "unavailable", "N/A"):
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _interpret_saturation_index(value: float | None) -> tuple[str, str, bool]:
+    """Return interpretation, warning level, and warning flag for LSI/CSI values."""
+    if value is None:
+        return "unknown", "unknown", False
+    if value < -0.5:
+        return "strongly corrosive / aggressive", "warning", True
+    if value < 0:
+        return "slightly corrosive", "notice", False
+    if value <= 0.3:
+        return "balanced", "ok", False
+    if value <= 0.5:
+        return "slight scaling tendency", "notice", False
+    return "strong scaling tendency", "warning", True
+
+
+class VioletSaturationIndexSensor(VioletPoolControllerEntity, SensorEntity):
+    """Base sensor for calculating pool saturation indexes."""
+
+    def __init__(
+        self,
+        coordinator: VioletPoolDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        *,
+        key: str,
+        translation_key: str,
+        name: str,
+        store_key: str,
+        input_prefix: str,
+    ) -> None:
+        """Initialize the saturation index sensor."""
+        self.config_entry = config_entry
+        self._store_key = store_key
+        self._input_prefix = input_prefix
+        description = SensorEntityDescription(
+            key=key,
+            translation_key=translation_key,
+            name=name,
+            icon="mdi:water-percent",
+            device_class=SensorDeviceClass.AQI,  # or None
+            state_class=SensorStateClass.MEASUREMENT,
+        )
+        super().__init__(coordinator, config_entry, description)
+
+    async def async_added_to_hass(self) -> None:
+        """Update immediately when local saturation index input numbers change."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self.config_entry.entry_id}_{self._store_key}_updated",
+                self.async_write_ha_state,
+            )
+        )
+
+    def _get_inputs(self) -> dict[str, float | None]:
+        """Return calculator inputs using controller values first, then manual values."""
+        inputs = self.hass.data.get(DOMAIN, {}).get(
+            f"{self.config_entry.entry_id}_{self._store_key}", {}
+        )
+        prefix = self._input_prefix
+        coordinator_data = self.coordinator.data or {}
+        manual_input_keys = {
+            "ph": f"{prefix}_ph",
+            "temperature_c": f"{prefix}_temperature",
+            "tds_mg_l": f"{prefix}_tds",
+            "calcium_hardness_mg_l_as_caco3": f"{prefix}_calcium",
+            "carbonate_alkalinity_mg_l_as_caco3": f"{prefix}_alkalinity",
+        }
+
+        values: dict[str, float | None] = {}
+        for input_name, source_fields in SATURATION_INDEX_SOURCE_FIELDS.items():
+            controller_value = next(
+                (
+                    parsed_value
+                    for source_field in source_fields
+                    if (parsed_value := _as_optional_float(coordinator_data.get(source_field)))
+                    is not None
+                ),
+                None,
+            )
+            values[input_name] = controller_value or _as_optional_float(
+                inputs.get(manual_input_keys[input_name])
+            )
+
+        return values
+
+    @staticmethod
+    def _missing_inputs(values: dict[str, float | None]) -> list[str]:
+        """Return names of inputs required before the result can be calculated."""
+        return [key for key, value in values.items() if value is None]
+
+    @property
+    def native_value(self) -> float | None:
+        """Calculate and return the saturation index value."""
+        if self.coordinator.data is None:
+            return None
+
+        try:
+            values = self._get_inputs()
+            if self._missing_inputs(values):
+                return None
+
+            ph = values["ph"]
+            temperature_c = values["temperature_c"]
+            tds = values["tds_mg_l"]
+            calcium_hardness = values["calcium_hardness_mg_l_as_caco3"]
+            carbonate_alkalinity = values["carbonate_alkalinity_mg_l_as_caco3"]
+
+            if (
+                ph is None
+                or temperature_c is None
+                or tds is None
+                or calcium_hardness is None
+                or carbonate_alkalinity is None
+                or min(tds, calcium_hardness, carbonate_alkalinity) <= 0
+            ):
+                return None
+
+            # Saturation index formula (LSI/CSI without cyanuric-acid correction):
+            # index = pH - pHs
+            # pHs = 9.3 + A + B - C - D
+            a = (math.log10(tds) - 1.0) / 10.0
+            b = -13.12 * math.log10(temperature_c + 273.15) + 34.55
+            c = math.log10(calcium_hardness) - 0.4
+            d = math.log10(carbonate_alkalinity)
+
+            phs = 9.3 + a + b - c - d
+            saturation_index = ph - phs
+
+            return round(saturation_index, 2)
+
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | float | bool]:
+        """Return the input values, interpretation and warning state."""
+        try:
+            values = self._get_inputs()
+            attributes: dict[str, str | float | bool] = {
+                key: value for key, value in values.items() if value is not None
+            }
+            missing_inputs = self._missing_inputs(values)
+        except (ValueError, TypeError):
+            attributes = {}
+            missing_inputs = []
+
+        value = self.native_value
+        interpretation, warning_level, warning = _interpret_saturation_index(value)
+        attributes.update(
+            {
+                "interpretation": interpretation,
+                "warning_level": warning_level,
+                "warning": warning,
+                "missing_inputs": ", ".join(missing_inputs),
+                "cyanuric_acid_correction": "not_applied",
+                "alkalinity_note": (
+                    "Use carbonate alkalinity / carbonate hardness for best results; "
+                    "total alkalinity can be misleading with softeners."
+                ),
+            }
+        )
+        return attributes
+
+
+class VioletLSISensor(VioletSaturationIndexSensor):
     """A specialized sensor for calculating the Langelier Saturation Index (LSI)."""
 
     def __init__(
@@ -472,60 +654,33 @@ class VioletLSISensor(VioletPoolControllerEntity, SensorEntity):
         coordinator: VioletPoolDataUpdateCoordinator,
         config_entry: ConfigEntry,
     ) -> None:
-        """Initializes the LSI sensor."""
-        description = SensorEntityDescription(
+        """Initialize the LSI sensor."""
+        super().__init__(
+            coordinator,
+            config_entry,
             key="lsi_calculator",
             translation_key="lsi_index",
             name="LSI Index",
-            icon="mdi:water-percent",
-            device_class=SensorDeviceClass.AQI, # or None
-            state_class=SensorStateClass.MEASUREMENT,
+            store_key="lsi_inputs",
+            input_prefix="lsi",
         )
-        super().__init__(coordinator, config_entry, description)
 
-    @property
-    def native_value(self) -> float | None:
-        """Calculate and return the LSI value."""
-        if self.coordinator.data is None:
-            return None
 
-        try:
-            ph_raw = self.coordinator.data.get("PH") or self.coordinator.data.get("pH_value")
-            temp_raw = self.coordinator.data.get("onewire1_value")  # Pool water temp
+class VioletCSISensor(VioletSaturationIndexSensor):
+    """A specialized sensor for calculating the Calcite Saturation Index (CSI)."""
 
-            if ph_raw is None or temp_raw is None:
-                return None
-                
-            ph = float(ph_raw)
-            temp_c = float(temp_raw)
-            
-            # Simplified LSI constants if not provided by user config yet
-            tds = 1000.0
-            calcium_hardness = 200.0
-            total_alkalinity = 100.0
-            
-            # LSI Formula
-            # LSI = pH - pHs
-            # pHs = (9.3 + A + B) - (C + D)
-            a = (math.log10(tds) - 1.0) / 10.0
-            b = -13.12 * math.log10(temp_c + 273.15) + 34.55
-            c = math.log10(calcium_hardness) - 0.4
-            d = math.log10(total_alkalinity)
-            
-            phs = (9.3 + a + b) - (c + d)
-            lsi = ph - phs
-            
-            return round(lsi, 2)
-            
-        except (ValueError, TypeError):
-            return None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, str]:
-        """Return the constants used for LSI calculation."""
-        return {
-            "tds_ppm": "1000",
-            "calcium_hardness_ppm": "200",
-            "total_alkalinity_ppm": "100",
-            "note": "Constants are currently hardcoded. Future versions will allow configuration.",
-        }
+    def __init__(
+        self,
+        coordinator: VioletPoolDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the CSI sensor."""
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="csi_calculator",
+            translation_key="csi_index",
+            name="CSI Index",
+            store_key="csi_inputs",
+            input_prefix="csi",
+        )

--- a/custom_components/violet_pool_controller/strings.json
+++ b/custom_components/violet_pool_controller/strings.json
@@ -1254,6 +1254,12 @@
           "error": "Error",
           "offline": "Offline"
         }
+      },
+      "lsi_index": {
+        "name": "LSI Result"
+      },
+      "csi_index": {
+        "name": "CSI Result"
       }
     },
     "binary_sensor": {
@@ -1554,6 +1560,36 @@
       },
       "flocculant_canister_volume": {
         "name": "Flocculant Canister Volume"
+      },
+      "lsi_ph": {
+        "name": "LSI pH Value"
+      },
+      "lsi_temperature": {
+        "name": "LSI Temperature"
+      },
+      "lsi_tds": {
+        "name": "LSI TDS"
+      },
+      "lsi_calcium": {
+        "name": "LSI Calcium Hardness"
+      },
+      "lsi_alkalinity": {
+        "name": "LSI Carbonate Alkalinity"
+      },
+      "csi_ph": {
+        "name": "CSI pH Value"
+      },
+      "csi_temperature": {
+        "name": "CSI Temperature"
+      },
+      "csi_tds": {
+        "name": "CSI TDS"
+      },
+      "csi_calcium": {
+        "name": "CSI Calcium Hardness"
+      },
+      "csi_alkalinity": {
+        "name": "CSI Carbonate Alkalinity"
       }
     },
     "select": {

--- a/custom_components/violet_pool_controller/translations/de.json
+++ b/custom_components/violet_pool_controller/translations/de.json
@@ -1773,6 +1773,12 @@
       },
       "di_rule_8_stopwatch": {
         "name": "DI-Regel 8 Restzeit"
+      },
+      "lsi_index": {
+        "name": "LSI Ergebnis"
+      },
+      "csi_index": {
+        "name": "CSI Ergebnis"
       }
     },
     "binary_sensor": {
@@ -2073,6 +2079,36 @@
       },
       "flocculant_canister_volume": {
         "name": "Flockungsmittel-Behälter-Volumen"
+      },
+      "lsi_ph": {
+        "name": "LSI pH-Wert"
+      },
+      "lsi_temperature": {
+        "name": "LSI Temperatur"
+      },
+      "lsi_tds": {
+        "name": "LSI TDS"
+      },
+      "lsi_calcium": {
+        "name": "LSI Calciumhärte"
+      },
+      "lsi_alkalinity": {
+        "name": "LSI Carbonathärte / Carbonat-Alkalität"
+      },
+      "csi_ph": {
+        "name": "CSI pH-Wert"
+      },
+      "csi_temperature": {
+        "name": "CSI Temperatur"
+      },
+      "csi_tds": {
+        "name": "CSI TDS"
+      },
+      "csi_calcium": {
+        "name": "CSI Calciumhärte"
+      },
+      "csi_alkalinity": {
+        "name": "CSI Carbonathärte / Carbonat-Alkalität"
       }
     },
     "select": {

--- a/custom_components/violet_pool_controller/translations/en.json
+++ b/custom_components/violet_pool_controller/translations/en.json
@@ -450,6 +450,8 @@
       "onewire6_value": {"name": "Heat Storage"},
       "onewire7_value": {"name": "Temperature Sensor 7"},
       "onewire8_value": {"name": "Temperature Sensor 8"},
+      "lsi_index": {"name": "LSI Result"},
+      "csi_index": {"name": "CSI Result"},
       "ph_value": {"name": "pH Value"},
       "orp_value": {"name": "ORP Value"},
       "pot_value": {"name": "Chlorine Content"},
@@ -878,7 +880,17 @@
       "chlorine_canister_volume": {"name": "Chlorine Canister Volume"},
       "ph_minus_canister_volume": {"name": "pH- Canister Volume"},
       "ph_plus_canister_volume": {"name": "pH+ Canister Volume"},
-      "flocculant_canister_volume": {"name": "Flocculant Canister Volume"}
+      "flocculant_canister_volume": {"name": "Flocculant Canister Volume"},
+      "lsi_ph": {"name": "LSI pH Value"},
+      "lsi_temperature": {"name": "LSI Temperature"},
+      "lsi_tds": {"name": "LSI TDS"},
+      "lsi_calcium": {"name": "LSI Calcium Hardness"},
+      "lsi_alkalinity": {"name": "LSI Carbonate Alkalinity"},
+      "csi_ph": {"name": "CSI pH Value"},
+      "csi_temperature": {"name": "CSI Temperature"},
+      "csi_tds": {"name": "CSI TDS"},
+      "csi_calcium": {"name": "CSI Calcium Hardness"},
+      "csi_alkalinity": {"name": "CSI Carbonate Alkalinity"}
     },
     "select": {
       "pump_mode": {"name": "Pump Mode", "state": {"off": "Off", "on": "On", "auto": "Auto"}},


### PR DESCRIPTION
### Motivation
- Provide built-in saturation index calculations (LSI and CSI) so users can see water balance status derived from controller readings or manual inputs.
- Allow manual override/entry of required inputs and persist those values across restarts to support installations without all sensors present.
- Surface clearer interpretation and warnings for saturation index results in the sensor attributes and UI translations.

### Description
- Introduce `LSI_INPUT_DEFINITIONS` and `CSI_INPUT_DEFINITIONS` plus `SATURATION_INDEX_SOURCE_FIELDS` in `const_features.py` to describe inputs and available controller data sources for saturation-index calculators.
- Add `VioletSaturationIndexInputNumber` in `number.py` (subclassing `RestoreEntity`) to expose local number inputs, restore last state, store values in `hass.data` and broadcast changes via the dispatcher using `async_dispatcher_send`, and create these input entities from `async_setup_entry` when `ph_control` is active.
- Refactor the previous LSI sensor into a reusable `VioletSaturationIndexSensor` in `sensor_modules/specialized.py`, add `VioletCSISensor` alongside `VioletLSISensor`, implement input resolution (controller-first then manual), calculation logic, interpretation/warning helper, and expose input/interpretation attributes.
- Wire the new CSI sensor into `sensor.py` and `sensor_modules/__init__.py` exports, and add translation strings in `strings.json` and localized translation files for the new sensors and input numbers.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5619f72918832ebf3c0c24676ca231)

## Summary by Sourcery

Add reusable saturation index calculation sensors (LSI and CSI) with support for both controller-derived and manually entered inputs, and surface interpreted balance status in sensor attributes.

New Features:
- Expose local input number entities for LSI and CSI parameters that can be manually set, restored across restarts, and used when controller data is unavailable.
- Introduce dedicated LSI and CSI saturation index sensors that compute indices from available inputs and provide interpretation and warning metadata.
- Wire the new CSI saturation index sensor into the sensor module exports and sensor setup alongside the existing LSI calculator.

Enhancements:
- Refactor the existing LSI calculator into a generic saturation index sensor base that handles input resolution, calculation, and attribute reporting.
- Define shared saturation index input and source field metadata to describe required parameters and map them to controller readings or manual inputs.
- Add translation entries for the new saturation index sensors and local input numbers to improve UI labelling and localization.