### PR TITLE
fix: verify_ssl bug in config flow + mypy type-safety cleanup for HA 2026.8

### DIFF
--- a/custom_components/violet_pool_controller/config_flow.py
+++ b/custom_components/violet_pool_controller/config_flow.py
@@ -50,6 +50,7 @@ from .config_flow_utils import (
 from .const import (
     AVAILABLE_FEATURES,
     CONF_ACTIVE_FEATURES,
+    CONF_ALLOW_UNSAFE_SWITCHES,
     CONF_API_URL,
     CONF_CONTROLLER_NAME,
     CONF_DEVICE_ID,
@@ -67,6 +68,7 @@ from .const import (
     CONF_USE_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    DEFAULT_ALLOW_UNSAFE_SWITCHES,
     DEFAULT_CONTROLLER_NAME,
     DEFAULT_POLLING_INTERVAL,
     DEFAULT_POOL_SIZE,
@@ -398,8 +400,6 @@ class ConfigFlow(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of safety settings."""
-        from .const import CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
-
         reconfigure_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         if reconfigure_entry is None:
             return self.async_abort(reason="reconfigure_failed")
@@ -739,14 +739,6 @@ class ConfigFlow(
                 active.add(feature_id)
 
         return sorted(active)
-
-    def _extract_active_features(self, ui: dict) -> list:
-        """Extract active features from legacy user input."""
-        return [
-            feature["id"]
-            for feature in AVAILABLE_FEATURES
-            if ui.get(f"enable_{feature['id']}", feature["default"])
-        ]
 
     def _generate_entry_title(self) -> str:
         """Generate the title for the config entry."""

--- a/custom_components/violet_pool_controller/config_flow_support.py
+++ b/custom_components/violet_pool_controller/config_flow_support.py
@@ -28,6 +28,7 @@ from .config_flow_utils import (
 from .const import (
     AVAILABLE_FEATURES,
     CONF_ACTIVE_FEATURES,
+    CONF_ALLOW_UNSAFE_SWITCHES,
     CONF_API_URL,
     CONF_CONTROLLER_NAME,
     CONF_DEVICE_ID,
@@ -45,6 +46,7 @@ from .const import (
     CONF_USE_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    DEFAULT_ALLOW_UNSAFE_SWITCHES,
     DEFAULT_CONTROLLER_NAME,
     DEFAULT_DISINFECTION_METHOD,
     DEFAULT_INVERT_COVER,
@@ -374,8 +376,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_safety(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle safety settings in options flow."""
-        from .const import CONF_ALLOW_UNSAFE_SWITCHES, DEFAULT_ALLOW_UNSAFE_SWITCHES
-
         if user_input is not None:
             self._updated_options.update(user_input)
             final_options = {**self.current_config, **self._updated_options}

--- a/custom_components/violet_pool_controller/config_flow_utils/sensor_helper.py
+++ b/custom_components/violet_pool_controller/config_flow_utils/sensor_helper.py
@@ -27,8 +27,10 @@ from ..const import (
     CONF_TIMEOUT_DURATION,
     CONF_USE_SSL,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
     DEFAULT_RETRY_ATTEMPTS,
     DEFAULT_TIMEOUT_DURATION,
+    DEFAULT_VERIFY_SSL,
 )
 from .validators import validate_credentials_strength
 
@@ -64,7 +66,7 @@ async def get_grouped_sensors(
             username=username,
             password=password,
             use_ssl=config_data.get(CONF_USE_SSL, False),
-            verify_ssl=True,
+            verify_ssl=config_data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             timeout=config_data.get(CONF_TIMEOUT_DURATION, DEFAULT_TIMEOUT_DURATION),
             max_retries=config_data.get(CONF_RETRY_ATTEMPTS, DEFAULT_RETRY_ATTEMPTS),
             dosing_standalone=config_data.get(CONF_DOSING_STANDALONE, DEFAULT_DOSING_STANDALONE),

--- a/custom_components/violet_pool_controller/number.py
+++ b/custom_components/violet_pool_controller/number.py
@@ -530,9 +530,9 @@ async def async_setup_entry(
                     key=str(input_config["key"]),
                     name=str(input_config["name"]),
                     icon=input_config.get("icon"),  # type: ignore[arg-type]
-                    native_unit_of_measurement=(
-                        input_config.get("unit_of_measurement")
-                    ),  # type: ignore[arg-type]
+                    native_unit_of_measurement=input_config.get(  # type: ignore[arg-type]
+                        "unit_of_measurement"
+                    ),
                     device_class=input_config.get("device_class"),  # type: ignore[arg-type]
                     entity_category=input_config.get("entity_category"),  # type: ignore[arg-type]
                     translation_key=cast(str | None, input_config.get("translation_key")),

--- a/custom_components/violet_pool_controller/safety_guard.py
+++ b/custom_components/violet_pool_controller/safety_guard.py
@@ -65,7 +65,7 @@ class _HassStorageBackend:
     def __init__(self, hass: HomeAssistant) -> None:
         from homeassistant.helpers.storage import Store
 
-        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
 
     async def async_load(self) -> dict[str, Any]:
         data = await self._store.async_load()

--- a/custom_components/violet_pool_controller/sensor_modules/specialized.py
+++ b/custom_components/violet_pool_controller/sensor_modules/specialized.py
@@ -476,7 +476,7 @@ def _as_optional_float(value: object) -> float | None:
     if value in (None, "", "unknown", "unavailable", "N/A"):
         return None
     try:
-        return float(value)
+        return float(value)  # type: ignore[arg-type]
     except (ValueError, TypeError):
         return None
 
@@ -541,7 +541,7 @@ class VioletSaturationIndexSensor(VioletPoolControllerEntity, SensorEntity):
             f"{self.config_entry.entry_id}_{self._store_key}", {}
         )
         prefix = self._input_prefix
-        coordinator_data = self.coordinator.data or {}
+        coordinator_data: Mapping[str, Any] = self.coordinator.data or {}
         manual_input_keys = {
             "ph": f"{prefix}_ph",
             "temperature_c": f"{prefix}_temperature",

--- a/custom_components/violet_pool_controller/service_mixins/climate.py
+++ b/custom_components/violet_pool_controller/service_mixins/climate.py
@@ -54,6 +54,8 @@ DOSING_SYSTEM_TO_KEY = {
 class ClimateServiceHandlersMixin:
     """Mixin for climate services."""
 
+    manager: Any
+
     async def handle_manage_pv_surplus(self, call: ServiceCall) -> None:
         """Handle PV surplus management service."""
         coordinators = await self.manager.get_coordinators_for_call(call)

--- a/custom_components/violet_pool_controller/service_mixins/cover.py
+++ b/custom_components/violet_pool_controller/service_mixins/cover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import HomeAssistantError
@@ -52,6 +53,8 @@ DOSING_SYSTEM_TO_KEY = {
 
 class CoverServiceHandlersMixin:
     """Mixin for cover services."""
+
+    manager: Any
 
     async def handle_control_cover_http(self, call: ServiceCall) -> None:
         """Control cover via HTTP setFunctionManually (NEW API)."""

--- a/custom_components/violet_pool_controller/service_mixins/dosing.py
+++ b/custom_components/violet_pool_controller/service_mixins/dosing.py
@@ -61,6 +61,8 @@ DOSING_SYSTEM_TO_KEY = {
 class DosingServiceHandlersMixin:
     """Mixin for dosing services."""
 
+    manager: Any
+
     async def handle_smart_dosing(self, call: ServiceCall) -> None:
         """Handle smart dosing service."""
         coordinators = await self.manager.get_coordinators_for_call(call)

--- a/custom_components/violet_pool_controller/service_mixins/extension.py
+++ b/custom_components/violet_pool_controller/service_mixins/extension.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import ServiceCall
@@ -61,6 +62,9 @@ DOSING_SYSTEM_TO_KEY = {
 
 class ExtensionServiceHandlersMixin:
     """Mixin for extension services."""
+
+    manager: Any
+    hass: Any
 
     async def handle_control_dmx_scenes(self, call: ServiceCall) -> None:
         """Handle DMX scene control service."""

--- a/custom_components/violet_pool_controller/service_mixins/pump.py
+++ b/custom_components/violet_pool_controller/service_mixins/pump.py
@@ -60,6 +60,8 @@ DOSING_SYSTEM_TO_KEY = {
 class PumpServiceHandlersMixin:
     """Mixin for pump services."""
 
+    manager: Any
+
     async def handle_control_pump(self, call: ServiceCall) -> None:
         """Handle pump control service."""
         coordinators = await self.manager.get_coordinators_for_call(call)

--- a/custom_components/violet_pool_controller/service_mixins/rules.py
+++ b/custom_components/violet_pool_controller/service_mixins/rules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import ServiceCall
@@ -53,6 +54,8 @@ DOSING_SYSTEM_TO_KEY = {
 
 class RulesServiceHandlersMixin:
     """Mixin for rules services."""
+
+    manager: Any
 
     async def handle_manage_digital_rules(self, call: ServiceCall) -> None:
         """Handle digital rules management service."""

--- a/custom_components/violet_pool_controller/service_mixins/system.py
+++ b/custom_components/violet_pool_controller/service_mixins/system.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import ServiceCall
@@ -53,6 +54,8 @@ DOSING_SYSTEM_TO_KEY = {
 
 class SystemServiceHandlersMixin:
     """Mixin for system services."""
+
+    manager: Any
 
     async def handle_test_output(self, call: ServiceCall) -> None:
         """Handle the output test service."""

--- a/custom_components/violet_pool_controller/switch.py
+++ b/custom_components/violet_pool_controller/switch.py
@@ -518,14 +518,14 @@ class VioletSwitch(VioletPoolControllerEntity, SwitchEntity):
                 # indefinitely.  Toggling ON via the bare switch entity is only
                 # allowed when an explicit bounded duration is provided; users
                 # should use the *_http services otherwise.
-                duration = kwargs.get("duration")
-                if duration is None:
+                raw_duration = kwargs.get("duration")
+                if raw_duration is None:
                     raise HomeAssistantError(
                         f"{key} cannot be turned ON without a duration. "
                         f"Use the {key.lower()}_http service with "
                         f"duration_seconds instead."
                     )
-                duration = self._validate_duration(duration, max_sec=3600)
+                duration = self._validate_duration(raw_duration, max_sec=3600)
                 result = await self.device.api.set_switch_state(
                     key=key, action=action, duration=duration
                 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for Violet Pool Controller config flow."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -11,6 +11,7 @@ from custom_components.violet_pool_controller.const import (
     CONF_DEVICE_NAME,
     CONF_POOL_SIZE,
     CONF_POOL_TYPE,
+    CONF_VERIFY_SSL,
     DOMAIN,
 )
 
@@ -167,3 +168,33 @@ class TestConfigFlow:
         assert VioletDeviceConfigFlow._is_ip_literal("2001:db8::1")
         assert not VioletDeviceConfigFlow._is_ip_literal("pool-controller")
         assert not VioletDeviceConfigFlow._is_ip_literal("pool.local")
+
+    async def test_get_grouped_sensors_honors_verify_ssl_false(self, hass):
+        """Sensor auto-detection must not force verify_ssl=True.
+
+        Regression test: get_grouped_sensors() used to hardcode
+        verify_ssl=True, so a controller configured with a self-signed
+        certificate (verify_ssl=False) would pass the connection test step
+        but then fail SSL verification during sensor auto-detection.
+        """
+        from custom_components.violet_pool_controller.config_flow_utils.sensor_helper import (
+            get_grouped_sensors,
+        )
+
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_readings = AsyncMock(return_value={"PUMP": 1})
+        mock_api_instance.dosing_standalone = False
+        mock_api_class = MagicMock(return_value=mock_api_instance)
+
+        config_data = {
+            CONF_API_URL: "192.168.178.55",
+            CONF_VERIFY_SSL: False,
+        }
+
+        with patch(
+            "custom_components.violet_pool_controller.config_flow_utils.sensor_helper.VioletPoolAPI",
+            mock_api_class,
+        ):
+            await get_grouped_sensors(hass, config_data)
+
+        assert mock_api_class.call_args.kwargs["verify_ssl"] is False


### PR DESCRIPTION
## Pull Request Title

fix: verify_ssl bug in config flow + mypy type-safety cleanup for HA 2026.8

### Description

- **What issue does this solve?** A full code review (errors, optimization, HA 2026.8 compatibility, no regressions for older supported versions), plus a follow-up config-flow optimization pass. Found and fixed a real bug: `get_grouped_sensors()` in the config flow hardcoded `verify_ssl=True`, ignoring the user's configured `CONF_VERIFY_SSL`. `_test_connection()` correctly reads it from config data, but the sensor auto-detection step immediately after does not — so a controller set up with a self-signed certificate (`verify_ssl=False`, a documented supported scenario per this repo's SSL policy) would pass the connection test and then fail with an SSL error during auto-detection, breaking setup. Also removed a dead method (`_extract_active_features`, unreferenced anywhere, superseded by `_detect_active_features`) and hoisted two same-module local imports to module level for consistency.
- **Why is this change necessary?** The `verify_ssl` bug silently breaks first-time setup for anyone using a self-signed cert. The rest is `mypy` (not run in CI) type-safety cleanup — 58 findings fixed down to 10 remaining, documented below as intentional/false-positive.
- **Additional context — scope note:** The task originally asked to "migrate to the new tmobus [tmodbus]". After investigation (cross-checked against `Xerolux/idm-heatpump-hass`, which did migrate its Modbus transport to `tmodbus`), we confirmed the Violet Pool Controller talks HTTP/JSON only — there is no Modbus transport in this integration to migrate. Confirmed with the requester; scope narrowed to review + optimization + 2026.8 compatibility only.

### Compatibility verification

Since `pytest-homeassistant-custom-component>=0.13.317` (needed for real HA 2026.3+) requires Python 3.14, and CI's own `tox.ini` only lints (not tests) on `py314` because that toolchain is "still experimental" there, the full test suite has never actually run against a current HA release in CI. To close that gap, this review installed Python 3.14.6 and the **real, current `homeassistant==2026.8.1` release** and ran the full suite against it directly, before and after each commit:

| Environment | Result |
|---|---|
| **HA 2026.8.1 / Python 3.14.6 (current release, target version)** | 506/506 tests pass, ruff clean, 0 deprecation warnings |
| HA 2026.2.3 / Python 3.13 (newest installable below the 3.14 floor) | 506/506 tests pass, ruff clean |
| `tox -e py312` (CI's exact pinned config) | 506/506 tests pass, ruff clean |
| `tox -e py313` (CI's exact pinned config) | 506/506 tests pass, ruff clean |

No regressions on any currently-supported version; the integration is confirmed compatible with the real HA 2026.8.1 release. A regression test (`test_get_grouped_sensors_honors_verify_ssl_false`) was added to lock in the `verify_ssl` fix.

`mypy` findings: **58 → 10**. The 10 remaining are intentional, not bugs:
- `ZeroconfServiceInfo` dual-import (`discovery.py`, `config_flow.py`, `__init__.py`): a deliberate `try`/`except ImportError` fallback to the pre-2024 `homeassistant.components.zeroconf` location, kept for backward compatibility per this repo's policy of not breaking older setups. Confirmed the old path was already removed in HA 2026.2.3+, so the fallback is dead on current HA but harmless — left in place intentionally rather than removed.
- `const_features.py` `.replace()` on `object` and `device.py`'s `config_entry` union-attr: both are mypy being unable to prove what's structurally guaranteed at the call site (a fixed literal dict of strings; a coordinator that is always constructed with a concrete `config_entry`), and the latter is additionally covered by a broad `except Exception -> UpdateFailed` a few lines down. No behavior change made here since there's no real risk to fix.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor (changes that do not add functionality or fix bugs, but improve the code's structure or readability)
- [x] Tests (adding or modifying tests)
- [ ] Build/CI (changes to the build system or continuous integration)
- [ ] Chore (maintenance tasks, updating dependencies, etc.)
- [ ] Other (please describe):

### Checklist

- [x] I have tested my changes locally (see compatibility table above).
- [x] All automated tests pass (`pytest tests/` — 506/506, on HA 2026.8.1/py3.14, HA 2026.2.3/py3.13, and both CI tox environments).
- [ ] I have added or updated necessary documentation — not applicable, no user-facing docs affected.
- [x] I have reviewed my code for any security vulnerabilities — the `verify_ssl` fix actually *improves* SSL-handling correctness (no verification is weakened; it now consistently honors the user's own setting instead of silently overriding it to strict in one code path).
- [x] My changes are backward-compatible — verified against HA 2026.2.3/py3.13 and the CI's py3.12/py3.13 tox environments in addition to the target py3.14/HA 2026.8.1.
- [x] I have followed the coding style and conventions of this project (`ruff check` clean).
- [ ] Changelog entry — not added; maintainer can fold into release notes at tag time.
- [ ] Version bump — to be handled separately per this repo's release-workflow policy (bump + tag after merge).

### Testing Instructions

1. `pip install -r requirements-dev.txt` (or `tox -e py312` / `tox -e py313`)
2. `python -m ruff check custom_components/violet_pool_controller/` → clean
3. `python -m mypy custom_components/violet_pool_controller/` → 10 findings, all documented above as intentional
4. `pytest tests/ -v` → 506 passed (includes new `test_get_grouped_sensors_honors_verify_ssl_false`)

### Notes for Reviewers

- The `verify_ssl` fix in `config_flow_utils/sensor_helper.py` is the one behavior change in this PR — everything else is type annotations, a `type: ignore` placement fix, dead-code removal, or import hoisting with no behavior change.
- `mypy` is not part of CI today; happy to also wire it into `validate.yml` in a follow-up if that's wanted, but kept this PR scoped to the fixes themselves.
- The `tmodbus`/Modbus migration originally referenced in the task title does not apply to this integration (HTTP/JSON only) — flagged and confirmed out of scope before starting, see description above.

## Summary by Sourcery

Fix SSL verification handling during config flow sensor auto-detection and tighten type safety across the Violet Pool Controller integration for Home Assistant 2026.8 compatibility.

Bug Fixes:
- Ensure get_grouped_sensors respects the configured CONF_VERIFY_SSL setting instead of forcing SSL verification during sensor auto-detection.
- Prevent unsafe pump switch activation without an explicit duration by validating the raw duration argument before toggling.

Enhancements:
- Hoist safety-related config constants to module-level imports in config flow and options support for clearer configuration handling.
- Remove unused legacy active-feature extraction helper in the config flow to reduce dead code.
- Improve type annotations and mypy friendliness across service mixins, safety storage, sensor modules, and number entities without changing runtime behavior.

Tests:
- Add a regression test verifying get_grouped_sensors honors verify_ssl=False when connecting to controllers with self-signed certificates.