### PR TITLE
fix: do not stringify the UNDEFINED name sentinel

### DIFF
--- a/custom_components/violet_pool_controller/entity.py
+++ b/custom_components/violet_pool_controller/entity.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.typing import UNDEFINED
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .device import VioletPoolDataUpdateCoordinator
@@ -184,16 +184,24 @@ def interpret_state_as_bool(raw_state: Any, key: str = "") -> bool | None:
     return None
 
 
-def strip_redundant_device_prefix(name: Any, *device_names: str | None) -> str | None:
+def strip_redundant_device_prefix(
+    name: Any, *device_names: str | None
+) -> str | UndefinedType | None:
     """Strip repeated device/controller prefixes from an entity name.
 
     Home Assistant already prepends the device name when ``has_entity_name`` is
     true. If a controller-provided output label also starts with the same device
     name (for example ``Violet Pool Controller Beleuchtung``), the generated
     entity id becomes duplicated. Return only the entity-specific suffix.
+
+    ``None`` and ``UNDEFINED`` are passed through untouched. ``UNDEFINED`` is
+    Home Assistant's "no name set" sentinel and is the default of
+    ``EntityDescription.name``; stringifying it would name the entity
+    "UndefinedType._singleton" instead of letting Home Assistant fall back to
+    the device name.
     """
-    if name is None:
-        return None
+    if name is None or name is UNDEFINED:
+        return name
 
     cleaned = str(name).strip()
     if not cleaned:

--- a/tests/test_entity_object_id.py
+++ b/tests/test_entity_object_id.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import UNDEFINED
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -21,6 +22,7 @@ if str(ROOT) not in sys.path:
 
 from custom_components.violet_pool_controller.entity import (  # noqa: E402
     VioletPoolControllerEntity,
+    strip_redundant_device_prefix,
 )
 
 _TRANSLATION_KEY = "component.violet_pool_controller.entity.sensor.pool_temperature.name"
@@ -49,9 +51,8 @@ def _attach(entity: VioletPoolControllerEntity, platform_data: MagicMock | None)
     entity.platform = platform_data
 
 
-@pytest.fixture
-def entity() -> VioletPoolControllerEntity:
-    """Create a base entity with a translated sensor description."""
+def _make_entity(description: SensorEntityDescription) -> VioletPoolControllerEntity:
+    """Build a base entity around the given description."""
     coordinator = MagicMock()
     coordinator.device.device_name = "Violet Pool Controller"
     coordinator.device.controller_name = "Violet Pool Controller"
@@ -60,12 +61,34 @@ def entity() -> VioletPoolControllerEntity:
     config_entry = MagicMock(spec=ConfigEntry)
     config_entry.entry_id = "test_entry"
 
-    description = SensorEntityDescription(
-        key="onewire1_value",
-        name="Pool Temperature",
-        translation_key="pool_temperature",
-    )
     return VioletPoolControllerEntity(coordinator, config_entry, description)
+
+
+@pytest.fixture
+def entity() -> VioletPoolControllerEntity:
+    """Create a base entity with a translated sensor description."""
+    return _make_entity(
+        SensorEntityDescription(
+            key="onewire1_value",
+            name="Pool Temperature",
+            translation_key="pool_temperature",
+        )
+    )
+
+
+@pytest.fixture
+def unnamed_entity() -> VioletPoolControllerEntity:
+    """Create a base entity whose description carries no name at all.
+
+    ``EntityDescription.name`` defaults to ``UNDEFINED``, so this is what any
+    description that simply omits ``name=`` looks like.
+    """
+    return _make_entity(
+        SensorEntityDescription(
+            key="onewire1_value",
+            translation_key="pool_temperature",
+        )
+    )
 
 
 def test_object_id_stays_english_for_translated_entity(entity):
@@ -100,3 +123,40 @@ def test_no_platform_data_does_not_raise(entity):
     _attach(entity, None)
 
     assert entity.suggested_object_id == "Pool Temperature"
+
+
+def test_nameless_entity_suggests_no_object_id(unnamed_entity):
+    """Without any name Home Assistant must fall back to naming by device."""
+    platform_data = _platform_data("Wassertemperatur")
+    platform_data.platform_translations = {}
+    platform_data.object_id_platform_translations = {}
+    platform_data.default_language_platform_translations = {}
+    _attach(unnamed_entity, platform_data)
+
+    # UNDEFINED means "no name of its own"; returning it verbatim would produce
+    # an entity_id like sensor.violet_pool_controller_undefinedtype_singleton.
+    assert unnamed_entity.suggested_object_id is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, UNDEFINED],
+    ids=["none", "undefined"],
+)
+def test_name_sanitizer_passes_through_sentinels(value):
+    """``None`` and ``UNDEFINED`` must survive the prefix stripping untouched.
+
+    ``UNDEFINED`` is the default of ``EntityDescription.name``. Stringifying it
+    would name the entity "UndefinedType._singleton".
+    """
+    assert strip_redundant_device_prefix(value, "Violet Pool Controller") is value
+
+
+def test_name_sanitizer_still_strips_the_device_prefix():
+    """The regular case keeps working."""
+    assert (
+        strip_redundant_device_prefix(
+            "Violet Pool Controller Beleuchtung", "Violet Pool Controller"
+        )
+        == "Beleuchtung"
+    )


### PR DESCRIPTION
## Pull Request Title

fix: do not stringify the UNDEFINED name sentinel

### Description

**What issue does this solve?** Follow-up to the Sourcery review on #394, which asked for coverage of the `UNDEFINED` branch in `suggested_object_id`. Writing that test surfaced an actual bug rather than just a coverage gap.

`strip_redundant_device_prefix()` guarded only against `None`:

```python
if name is None:
    return None
cleaned = str(name).strip()
```

`EntityDescription.name` defaults to `UNDEFINED`, Home Assistant's "this entity has no name of its own" sentinel. That sentinel is not `None`, so it fell through to `str()`:

```python
>>> strip_redundant_device_prefix(UNDEFINED, "Violet Pool Controller")
'UndefinedType._singleton'
```

The result was then assigned to `_attr_name`, which would produce an entity displayed as **"UndefinedType._singleton"** with an entity_id of `sensor.violet_pool_controller_undefinedtype_singleton` — instead of Home Assistant's intended fallback of naming the entity after its device.

**Reachability, stated plainly:** every entity description in the integration currently passes `name=`, so this is **not reachable today**. It is one forgotten argument away, and `UNDEFINED` is the framework default, so the failure mode is silent and ugly rather than loud.

Passing the sentinel through also makes the `UNDEFINED` branch of `suggested_object_id` reachable — which is what the review was asking about. It is now covered, together with the sentinel handling itself.

**Why is this change necessary?** A description that merely omits `name=` should name the entity after its device, which is the documented Home Assistant behaviour — not produce an internal repr as the user-visible name.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor (changes that do not add functionality or fix bugs, but improve the code's structure or readability)
- [x] Tests (adding or modifying tests)
- [ ] Build/CI (changes to the build system or continuous integration)
- [ ] Chore (maintenance tasks, updating dependencies, etc.)
- [ ] Other (please describe):

### Checklist

- [x] I have tested my changes locally or in a staging environment. Full suite green on **HA 2026.2.3** and on **HA 2026.1.3** (the declared minimum): 523 passed on both. `ruff check` clean.
- [x] All automated tests pass.
- [x] I have added or updated necessary documentation — the behaviour is documented in the function docstring.
- [x] I have reviewed my code for any security vulnerabilities. Not applicable; this only affects entity naming.
- [x] My changes are backward-compatible. No entity currently hits this path, so no existing entity_id or name changes.
- [x] I have followed the coding style and conventions of this project.
- [ ] I have added a changelog entry — not added, since the bug was never reachable in a released version and would only add noise to the 2.3.4 notes. Happy to add one if you'd prefer.
- [ ] I have updated the version number — left at 2.3.4; say the word if you want a 2.3.5.

### Related Issue(s)

Follow-up to the Sourcery review comment on #394.

### Testing Instructions

1. `pytest tests/test_entity_object_id.py -v` — 8 tests.
2. The two new sentinel tests fail on `main` and pass here:
   - `test_name_sanitizer_passes_through_sentinels[undefined]`
   - `test_nameless_entity_suggests_no_object_id`

### Notes for Reviewers

- The return type widened to `str | UndefinedType | None`. Callers already treat the value as opaque and hand it straight to `_attr_name`, where `UNDEFINED` is exactly the value Home Assistant expects for "no name".
- The `None` path is unchanged and still covered.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Eteczbx2hUNBHyFV53eVe)_

## Summary by Sourcery

Handle Home Assistant's UNDEFINED name sentinel correctly in entity naming and ensure it is passed through without being stringified while preserving existing prefix-stripping behavior.

Bug Fixes:
- Prevent the UNDEFINED entity name sentinel from being stringified and used as a user-visible name or in generated entity_ids.
- Ensure that nameless entities fall back to Home Assistant's device-based naming instead of producing an internal sentinel representation.

Tests:
- Add tests covering sentinel handling in strip_redundant_device_prefix, including UNDEFINED and None passthrough and regular prefix-stripping behavior.
- Add tests verifying that entities without an explicit name do not suggest an object_id, making the UNDEFINED branch of suggested_object_id reachable.