### PR TITLE
docs: date the 2.5.0 changelog section for the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ steht, erfährt also auch niemand dort.
 
 > **Language Note:** This changelog is written in German.
 
-## Version 2.5.0 (unveröffentlicht)
+## Version 2.5.0 (2026-08-18)
 
 Minor-Release mit zwei Schwerpunkten: die Datenpunkt-Auswahl gilt jetzt für
 **alle** Plattformen statt nur für Sensoren, und eine Reihe von Entitäten trägt


### PR DESCRIPTION
## Pull Request Title

docs: date the 2.5.0 changelog section for the release

### Description

The 2.5.0 section still carried `(unveröffentlicht)`. That heading is what the release workflow lifts into the GitHub release body, so the release page would have announced itself as unreleased. Dated `2026-08-18`, the day 2.5.0 is cut.

Nothing else changes — one line in `CHANGELOG.md`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor (changes that do not add functionality or fix bugs, but improve the code's structure or readability)
- [ ] Tests (adding or modifying tests)
- [ ] Build/CI (changes to the build system or continuous integration)
- [ ] Chore (maintenance tasks, updating dependencies, etc.)
- [ ] Other (please describe):

### Checklist

- [x] I have tested my changes locally or in a staging environment. The release workflow only requires a `## Version 2.5.0 ` heading; the date is what readers see.
- [x] All automated tests pass.
- [x] I have added or updated necessary documentation.
- [x] I have reviewed my code for any security vulnerabilities. No code changes.
- [x] My changes are backward-compatible (if applicable).
- [x] I have followed the coding style and conventions of this project.
- [x] I have added a changelog entry. This *is* the changelog entry.
- [ ] I have updated the version number in `const.py` and `manifest.json` — already 2.5.0 from #401.

### Related Issue(s)

Follow-up to #401.

### Testing Instructions

`grep '^## Version 2.5.0' CHANGELOG.md` shows the date rather than `(unveröffentlicht)`.

### Notes for Reviewers

Needs to land before the `v2.5.0` tag, otherwise the release page repeats the word "unveröffentlicht".

---
_Generated by [Claude Code](https://claude.ai/code/session_015W2Pqswso34cs9AFLpZD5L)_

## Summary by Sourcery

Documentation:
- Date the Version 2.5.0 changelog section for the release.