### PR TITLE
docs: Wärmepumpen-Blueprint — was nach dem Import aufs Dashboard gehört

### DIFF
--- a/blueprints/automation/pool_heatpump_cooling.yaml
+++ b/blueprints/automation/pool_heatpump_cooling.yaml
@@ -27,7 +27,12 @@ blueprint:
     - input_number helper for the target temperature
       (Settings -> Devices & Services -> Helpers -> Number)
 
-    VERSION: 1.0.0 (2026-08-17)
+    ON THE DASHBOARD: this blueprint creates an automation, not a climate
+    entity - the automation entity is only its on/off switch. Put the
+    input_number helper on the dashboard to set the temperature, next to the
+    pool temperature sensor and the heat pump's own climate entity.
+
+    VERSION: 1.1.0 (2026-08-19)
   domain: automation
   source_url: https://github.com/xerolux/violet-hass/blob/main/blueprints/automation/pool_heatpump_cooling.yaml
   homeassistant:

--- a/docs/wiki/Automations.de.md
+++ b/docs/wiki/Automations.de.md
@@ -516,6 +516,34 @@ Blueprint verbindet beides:
 Modi werden nur gesendet, wenn die Wärmepumpe sie in `hvac_modes` meldet, und
 solange ein Messwert `unavailable` ist, wird nichts geschrieben.
 
+**Nach dem Import: was aufs Dashboard gehört**
+
+Der Blueprint erzeugt eine *Automatisierung*. Die Entität, die danach im
+Dashboard auftaucht (`automation.violet_pool_heat_pump_heating_cooling`), ist
+deren Ein/Aus-Schalter — mehr zeigt sie nicht an. Die Solltemperatur stellst du
+am `input_number`-Helper ein; ein eigenes Climate-Objekt legt der Blueprint
+nicht an, denn genau weil der Controller keinen `cool`-Modus hat, gibt es den
+Blueprint überhaupt. Geregelt wird über die Climate-Entität der Wärmepumpe.
+
+Eine passende Karte — Entity-IDs an die eigene Anlage anpassen:
+
+```yaml
+type: entities
+title: Pool-Temperatur
+entities:
+  - entity: input_number.pool_solltemperatur   # hier wird die Temperatur eingestellt
+    name: Solltemperatur
+  - entity: sensor.violet_pool_controller_poolwasser
+    name: Ist-Temperatur
+  - entity: climate.waermepumpe
+    name: Wärmepumpe
+  - entity: automation.violet_pool_heat_pump_heating_cooling
+    name: Regelung aktiv
+```
+
+Der Blueprint schreibt jede Änderung am Helper auf die Wärmepumpe durch: der
+Wert im Helper ist damit der Wert, auf den die Wärmepumpe tatsächlich regelt.
+
 ---
 
 *Zurück: [Services](Services) | Weiter: [Troubleshooting](Troubleshooting)*

--- a/docs/wiki/Automations.md
+++ b/docs/wiki/Automations.md
@@ -514,6 +514,34 @@ pump through its own integration, and the blueprint ties the two together:
 Modes are only sent when the heat pump advertises them in `hvac_modes`, and
 nothing is written while a reading is `unavailable`.
 
+**After importing: what belongs on the dashboard**
+
+The blueprint creates an *automation*. The entity that shows up afterwards
+(`automation.violet_pool_heat_pump_heating_cooling`) is its on/off switch and
+nothing more. You set the target temperature on the `input_number` helper; the
+blueprint does not create a climate entity of its own, because the missing
+`cool` mode on the controller is the very reason the blueprint exists. The
+regulating is done through the heat pump's own climate entity.
+
+A card that fits — adjust the entity ids to your installation:
+
+```yaml
+type: entities
+title: Pool Temperature
+entities:
+  - entity: input_number.pool_target_temperature   # this is where you set it
+    name: Target
+  - entity: sensor.violet_pool_controller_pool_water
+    name: Current
+  - entity: climate.heat_pump
+    name: Heat pump
+  - entity: automation.violet_pool_heat_pump_heating_cooling
+    name: Control active
+```
+
+Every change on the helper is written through to the heat pump, so the value in
+the helper is the value the heat pump actually regulates to.
+
 ---
 
 *Back: [Services](Services) | Next: [Troubleshooting](Troubleshooting)*


### PR DESCRIPTION
## Pull Request Title

docs: Wärmepumpen-Blueprint — was nach dem Import aufs Dashboard gehört

### Description

- **What issue does this solve?** Aus dem Forum (19.08.2026, 17:40):

  > Ich habe oben genannten Blueprint zur automatischen Kühlung/Heizung importiert, den Helper angelegt und die Entitäten zugewiesen. Das dann in einem Test-Dashboard angezeigt. […] Ich hätte erwartet, dass da ein climate-object kommt, irgendwo muss ich ja die Solltemperatur einstellen.

  Auf seinem Screenshot steht eine einzelne Karte: „Violet Pool - Heat Pump Heating & Cooling — Ein". Das ist die **Automatisierung**, die der Blueprint anlegt — also nur deren Ein/Aus-Schalter. Kein Fehler, aber die naheliegende Fehlannahme: dass der Blueprint ein Climate-Objekt mitbringt.

- **Why is this change necessary?** Der Blueprint legt bewusst kein eigenes Climate-Objekt an — der fehlende `cool`-Modus des Controllers ist ja der Grund, warum es ihn gibt. Die Solltemperatur sitzt im `input_number`-Helper. Das stand bisher **einmal**, in der Beschreibung des Helper-Eingabefelds im Import-Dialog — genau dort, wo man es beim Ausfüllen überliest und danach nie wieder sieht.

- **Additional context:** Kein Code betroffen, keine Verhaltensänderung.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Tests (adding or modifying tests)

### Checklist

- [x] `docs/wiki/Automations.de.md` und `docs/wiki/Automations.md` erklären nach dem Blueprint-Abschnitt, was aufs Dashboard gehört, inklusive fertiger `entities`-Karte zum Kopieren (Helper = Sollwert, Pool-Sensor = Istwert, Climate der Wärmepumpe, Automatisierung als Schalter).
- [x] Die Blueprint-Beschreibung selbst enthält denselben Hinweis (`ON THE DASHBOARD:`), Blueprint-`VERSION` auf 1.1.0 gehoben.
- [x] Blueprint bleibt gegen HA-Schema gültig (`tests/test_blueprints.py` prüft das in CI; lokal mit HA-YAML-Loader geparst).
- [x] **Keine Versionsanhebung der Integration** — reine Doku, kein Release nötig. Die Wiki-Seiten aktualisiert `docs.yml` beim Merge auf `main` von selbst.

### Testing Instructions

1. Wiki-Seite „Automations" nach dem Merge öffnen → Abschnitt „Nach dem Import: was aufs Dashboard gehört" steht direkt unter der Blueprint-Beschreibung.
2. Blueprint neu importieren → der Hinweis steht in der Beschreibung im Import-Dialog.

### Notes for Reviewers

- Alternative wäre gewesen, dem Blueprint ein Template-Climate beizustellen. Habe ich bewusst nicht gemacht: Das wäre ein zweites Regelobjekt neben dem der Wärmepumpe, mit genau der Doppeldeutigkeit („welcher Sollwert gilt jetzt?"), die der Blueprint gerade auflöst. Wenn du das anders siehst, ist das der Punkt zum Widersprechen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyiXTs8jwynBxsNdSfm9ds)_