### PR TITLE
fix(update): confirm firmware updates by version when the state stays stale

### DIFF
--- a/custom_components/violet_pool_controller/update.py
+++ b/custom_components/violet_pool_controller/update.py
@@ -127,6 +127,9 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
     # Update-state polling cadence (seconds) and maximum task lifetime before
     # the safety net aborts. Exposed as class constants so tests can shrink them.
     _UPDATE_POLL_INTERVAL = 5
+    # How often (seconds) the polling task re-reads the firmware version to see
+    # whether the install already landed while the state string stayed stale.
+    _UPDATE_VERSION_REFRESH_INTERVAL = 30
     _UPDATE_MAX_LIFETIME = 600  # 10 minutes
     # Abort progress tracking if the reported state is byte-identical for this
     # many consecutive polls — a static state means the update log is either
@@ -150,6 +153,11 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
         self._update_progress: int | None = None
         self._update_status_text: str | None = None
         self._update_task: asyncio.Task[None] | None = None
+        # Version checkpoints are a fallback for controllers that keep the final
+        # update.log contents instead of returning STANDBY after a successful
+        # reboot: a changed installed version proves the update finished.
+        self._update_start_version: str | None = None
+        self._update_target_version: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -217,14 +225,99 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
         """
         return self._update_in_progress
 
+    def _remember_update_versions(self, target_version: str | None = None) -> None:
+        """Store the firmware versions used to confirm completion after a reboot."""
+        if not self.coordinator.data:
+            self._update_start_version = None
+            self._update_target_version = target_version
+            return
+
+        info = parse_firmware_info(self.coordinator.data)
+        self._update_start_version = info.installed_version
+        self._update_target_version = target_version or info.available_version
+
+    def _firmware_version_confirms_completion(self) -> bool:
+        """Return True when refreshed firmware data proves the update completed."""
+        if not self.coordinator.data:
+            return False
+
+        current_version = parse_firmware_info(self.coordinator.data).installed_version
+        if not current_version:
+            return False
+
+        if self._update_target_version and current_version == self._update_target_version:
+            return True
+
+        return bool(
+            self._update_start_version and current_version != self._update_start_version
+        )
+
+    def _controller_state_is_stale(self) -> bool:
+        """Return True when a non-STANDBY state belongs to an already installed update.
+
+        The raw readings are used on purpose: parse_firmware_info drops the
+        available version once it equals the installed one, which is exactly the
+        signal needed here. When the controller advertises an available version
+        and it matches what is installed, nothing is left to install, so a
+        lingering update.log is leftover output rather than a running update.
+
+        An empty available version is not treated as stale — the controller may
+        simply not have reached the update server yet, and suppressing a genuine
+        in-progress update would be worse than tracking one extra log.
+        """
+        data = self.coordinator.data
+        if not data:
+            return False
+
+        installed = str(data.get("SYSTEM_swversion", "") or "").strip() or str(
+            data.get("SW_VERSION", "") or ""
+        ).strip()
+        available = str(data.get("SYSTEM_availableversion", "") or "").strip() or str(
+            data.get("SW_UPDATE_AVAILABLE", "") or ""
+        ).strip()
+
+        return bool(installed and available and installed == available)
+
+    def _clear_update_tracking(self) -> None:
+        """Reset local update progress and version checkpoints."""
+        self._update_in_progress = False
+        self._update_progress = None
+        self._update_status_text = None
+        self._update_start_version = None
+        self._update_target_version = None
+        self.async_write_ha_state()
+
+    async def _refresh_firmware_data(self) -> bool:
+        """Refresh coordinator data without failing update progress tracking."""
+        try:
+            await self.coordinator.async_request_refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Could not refresh firmware version while tracking update on %s: %s",
+                self.coordinator.device.device_name,
+                err,
+            )
+            return False
+        return True
+
     async def _poll_update_state(self) -> None:
-        """Poll the controller for live update status until STANDBY or timeout.
+        """Poll update status until STANDBY, a version change, or timeout.
 
         Runs as a background task after async_install or after startup detection.
         Updates _update_in_progress, _update_progress, and _update_status_text
         and writes HA state on each iteration. Resilient to transient errors.
+
+        Some controllers never return to STANDBY after a successful reboot and
+        keep serving the final update.log instead. The periodic version refresh
+        catches that case: once the installed firmware version has changed (or
+        reached the target version), the update is complete regardless of what
+        the state string still says.
         """
         interval = self._UPDATE_POLL_INTERVAL
+        version_refresh_interval = max(self._UPDATE_VERSION_REFRESH_INTERVAL, interval)
+        next_version_refresh = version_refresh_interval
         elapsed = 0
         last_state: str | None = None
         unchanged = 0
@@ -247,11 +340,8 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
 
             normalized = (state or "").strip()
             if normalized.upper() == "STANDBY":
-                self._update_in_progress = False
-                self._update_progress = None
-                self._update_status_text = None
-                self.async_write_ha_state()
-                await self.coordinator.async_request_refresh()
+                await self._refresh_firmware_data()
+                self._clear_update_tracking()
                 return
 
             # Stale detection: a static, never-changing state means the update
@@ -269,11 +359,8 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
                         unchanged * interval,
                         (last_state or "")[:120],
                     )
-                    self._update_in_progress = False
-                    self._update_progress = None
-                    self._update_status_text = None
-                    self.async_write_ha_state()
-                    await self.coordinator.async_request_refresh()
+                    await self._refresh_firmware_data()
+                    self._clear_update_tracking()
                     return
             else:
                 unchanged = 0
@@ -284,10 +371,40 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
             self._update_status_text = normalized
             self.async_write_ha_state()
 
+            if elapsed >= next_version_refresh:
+                if (
+                    await self._refresh_firmware_data()
+                    and self._firmware_version_confirms_completion()
+                ):
+                    _LOGGER.info(
+                        "Firmware update on %s completed; installed version changed "
+                        "although the update state remained %r",
+                        self.coordinator.device.device_name,
+                        normalized[:120],
+                    )
+                    self._clear_update_tracking()
+                    return
+                next_version_refresh += version_refresh_interval
+
             await asyncio.sleep(interval)
             elapsed += interval
 
-        # Safety net: exceeded max lifetime without reaching STANDBY.
+        # Safety net: exceeded max lifetime. Do one final version check before
+        # declaring failure — the install may have landed on a controller that
+        # never clears its update state.
+        if (
+            await self._refresh_firmware_data()
+            and self._firmware_version_confirms_completion()
+        ):
+            _LOGGER.info(
+                "Firmware update on %s completed before the timeout; ignoring "
+                "stale update state %r",
+                self.coordinator.device.device_name,
+                (last_state or "")[:120],
+            )
+            self._clear_update_tracking()
+            return
+
         _LOGGER.warning(
             "Firmware update on %s did not reach STANDBY within %d seconds; "
             "aborting progress tracking (last state: %r)",
@@ -295,11 +412,7 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
             self._UPDATE_MAX_LIFETIME,
             (last_state or "")[:120],
         )
-        self._update_in_progress = False
-        self._update_progress = None
-        self._update_status_text = None
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        self._clear_update_tracking()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to HA.
@@ -337,12 +450,22 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
             )
             return
 
+        if self._controller_state_is_stale():
+            _LOGGER.debug(
+                "Ignoring stale firmware update state on %s at startup (%s): the "
+                "installed version already matches the available one",
+                self.coordinator.device.device_name,
+                normalized[:120],
+            )
+            return
+
         _LOGGER.info(
             "Detected in-progress firmware update on %s at startup (state=%s); "
             "resuming progress tracking",
             self.coordinator.device.device_name,
             normalized,
         )
+        self._remember_update_versions()
         self._update_in_progress = True
         self._update_status_text = normalized
         self._update_progress = _parse_update_progress(normalized)
@@ -387,19 +510,28 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
             # Guard 2: an update may have been started externally (another client,
             # a previous crashed task). Probe the controller before triggering.
             current_state = await self.coordinator.device.api.get_update_state()
-            if (current_state or "").strip().upper() != "STANDBY":
+            normalized_state = (current_state or "").strip()
+            if normalized_state.upper() != "STANDBY" and not self._controller_state_is_stale():
                 _LOGGER.warning(
                     "Update on %s already in progress (state=%s); starting progress tracking",
                     self.coordinator.device.device_name,
                     current_state,
                 )
+                self._remember_update_versions(version)
                 self._update_in_progress = True
-                self._update_status_text = (current_state or "").strip()
-                self._update_progress = _parse_update_progress(self._update_status_text or "")
+                self._update_status_text = normalized_state
+                self._update_progress = _parse_update_progress(normalized_state)
                 self.async_write_ha_state()
                 self._update_task = asyncio.create_task(self._poll_update_state())
                 raise HomeAssistantError(
                     "Update läuft bereits auf der Steuerung"
+                )
+
+            if normalized_state.upper() != "STANDBY":
+                _LOGGER.debug(
+                    "Ignoring stale firmware update state on %s before install: %s",
+                    self.coordinator.device.device_name,
+                    normalized_state[:120],
                 )
 
             _LOGGER.info(
@@ -407,6 +539,7 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
                 self.coordinator.device.device_name,
             )
 
+            self._remember_update_versions(version or self.latest_version)
             response = await self.coordinator.device.api.init_update()
 
             if response and response != "STARTING":
@@ -428,6 +561,8 @@ class VioletPoolControllerUpdateEntity(_VioletCoordinatorEntity, UpdateEntity):
         except HomeAssistantError:
             raise
         except Exception as err:
+            self._update_start_version = None
+            self._update_target_version = None
             _LOGGER.error("Failed to initiate firmware update: %s", err)
             raise HomeAssistantError(f"Firmware update failed: {err}") from err
 

--- a/tests/test_update_stale_state.py
+++ b/tests/test_update_stale_state.py
@@ -1,0 +1,116 @@
+"""Regression tests for stale firmware update states."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.violet_pool_controller.update import (
+    VioletPoolControllerUpdateEntity,
+)
+
+
+def _make_entity(data: dict[str, str]) -> tuple[VioletPoolControllerUpdateEntity, MagicMock]:
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = True
+    coordinator.device.device_name = "Violet Pool Controller"
+    coordinator.device.device_info = {
+        "identifiers": {("violet_pool_controller", "test")},
+        "name": "Violet Pool Controller",
+        "manufacturer": "PoolDigital GmbH & Co. KG",
+        "model": "Violet Pool Controller",
+    }
+    coordinator.async_request_refresh = AsyncMock()
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry_id"
+
+    entity = VioletPoolControllerUpdateEntity(coordinator, config_entry)
+    entity.async_write_ha_state = MagicMock()  # type: ignore[assignment]
+    return entity, coordinator
+
+
+@pytest.mark.asyncio
+async def test_poll_completes_on_version_change_without_standby(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale update.log must not cause a false ten-minute timeout."""
+    entity, coordinator = _make_entity(
+        {
+            "SYSTEM_swversion": "1.1.9",
+            "SYSTEM_availableversion": "1.2.0",
+        }
+    )
+
+    coordinator.device.api.get_update_state = AsyncMock(
+        return_value="installation completed (100%)"
+    )
+
+    async def refresh_version() -> None:
+        coordinator.data["SYSTEM_swversion"] = "1.2.0"
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_version)
+
+    entity._update_in_progress = True
+    entity._update_start_version = "1.1.9"
+    entity._update_target_version = "1.2.0"
+    monkeypatch.setattr(entity, "_UPDATE_VERSION_REFRESH_INTERVAL", 5)
+    monkeypatch.setattr(entity, "_UPDATE_MAX_LIFETIME", 15)
+
+    async def fast_sleep(_seconds: float) -> None:
+        return None
+
+    import custom_components.violet_pool_controller.update as update_mod
+
+    monkeypatch.setattr(update_mod.asyncio, "sleep", fast_sleep)
+
+    await entity._poll_update_state()
+
+    assert entity._update_in_progress is False
+    assert entity._update_progress is None
+    assert entity._update_status_text is None
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_ignores_stale_state_for_installed_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed update log must not be resumed after an HA restart."""
+    entity, coordinator = _make_entity(
+        {
+            "SYSTEM_swversion": "1.2.0",
+            "SYSTEM_availableversion": "1.2.0",
+        }
+    )
+    coordinator.device.api.get_update_state = AsyncMock(
+        return_value="installation completed (100%)"
+    )
+
+    parent_added = AsyncMock()
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", parent_added)
+
+    await entity.async_added_to_hass()
+
+    parent_added.assert_awaited_once()
+    assert entity._update_in_progress is False
+    assert entity._update_task is None
+
+
+def test_version_change_confirms_completion() -> None:
+    """The target version is accepted even while update state remains stale."""
+    entity, coordinator = _make_entity(
+        {
+            "SYSTEM_swversion": "1.1.9",
+            "SYSTEM_availableversion": "1.2.0",
+        }
+    )
+    entity._update_start_version = "1.1.9"
+    entity._update_target_version = "1.2.0"
+
+    assert entity._firmware_version_confirms_completion() is False
+
+    coordinator.data["SYSTEM_swversion"] = "1.2.0"
+
+    assert entity._firmware_version_confirms_completion() is True


### PR DESCRIPTION
Rebuilt version of #386 on top of current `main`.

## Problem

Some controllers never return `STANDBY` after they reboot into the new firmware and keep serving the final contents of `/home/violet/log/update.log`. Progress tracking then ran until the ten-minute safety net expired and logged a failure for an update that had actually succeeded.

## Fix

- Record the installed and target firmware version when tracking starts, and re-read them every 30s while polling. A changed installed version (or one that reached the target) ends tracking as a success regardless of what the state string still reports.
- The safety net does one final version check before declaring failure.
- Startup detection and `async_install` ignore a non-STANDBY state when the controller advertises an available version that already equals the installed one — nothing is left to install. An empty available version is deliberately *not* treated as stale, so a genuine update on a controller that has not reached the update server is still tracked.

This complements the existing `_looks_like_active_update` keyword heuristic and the unchanged-state counter on `main` rather than replacing them.

## Why not #386

#386 predates both of those heuristics and conflicts with them. Its stale check also could not work as written: it compared `FirmwareUpdateInfo.installed_version` against `available_version`, but `parse_firmware_info` sets `available_version` to `None` exactly when the two are equal, so the branch was unreachable — which is why its test failed CI on Python 3.12/3.13. The check here reads the raw readings instead.

Closes #386.

## Verification

- `pytest tests/` — 856 passed, 2 skipped
- `ruff check` — clean
- `mypy` — no issues in 66 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)